### PR TITLE
[Feature] IconButton 컴포넌트 추가

### DIFF
--- a/components/ui/icon-button.tsx
+++ b/components/ui/icon-button.tsx
@@ -5,15 +5,17 @@ import { twMerge } from 'tailwind-merge'
 
 interface IconButtonProps extends ComponentProps<'button'> {
   Icon: SvgIconComponent
+  label: string
   iconClassName?: string
 }
 
-const IconButton = ({ Icon, iconClassName, className, ...props }: IconButtonProps) => {
+const IconButton = ({ Icon, label, iconClassName, className, ...props }: IconButtonProps) => {
   return (
     <button
       className={twMerge('inline-flex items-center justify-center p-2 text-gray-400', className)}
       type="button"
       {...props}
+      aria-label={label}
     >
       <Icon className={iconClassName} />
     </button>

--- a/components/ui/icon-button.tsx
+++ b/components/ui/icon-button.tsx
@@ -1,0 +1,23 @@
+import { ComponentProps } from 'react'
+
+import { SvgIconComponent } from '@mui/icons-material'
+import { twMerge } from 'tailwind-merge'
+
+interface IconButtonProps extends ComponentProps<'button'> {
+  Icon: SvgIconComponent
+  iconClassName?: string
+}
+
+const IconButton = ({ Icon, iconClassName, className, ...props }: IconButtonProps) => {
+  return (
+    <button
+      className={twMerge('inline-flex items-center justify-center p-2 text-gray-400', className)}
+      type="button"
+      {...props}
+    >
+      <Icon className={iconClassName} />
+    </button>
+  )
+}
+
+export default IconButton


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="192" alt="image" src="https://github.com/user-attachments/assets/c7663627-b033-4e95-9a72-7bbc87d4b348">

## 📄 기타

테스트용 코드
```js
'use client'

import CopyIcon from '@mui/icons-material/ContentCopySharp'
import BackIcon from '@mui/icons-material/ArrowBackIosSharp'
import CloseIcon from '@mui/icons-material/CloseSharp'
import SendIcon from '@mui/icons-material/SendSharp'
import IconButton from '@/components/ui/icon-button'

const HomePage = () => {
  const handleCopy = () => {
    console.log('Copy action')
  }

  return (
    <main className="bg-primary p-4">
      <IconButton Icon={BackIcon} label="뒤로가기" />
      <IconButton Icon={SendIcon} className="text-blue" label="전송" />
      <IconButton Icon={CloseIcon} className="text-white" label="닫기" />
      <IconButton Icon={CopyIcon} onClick={handleCopy} label="복사" />
    </main>
  )
}

export default HomePage
```

## Sourcery에 의한 요약

새로운 기능:
- 버튼 요소 내에서 Material UI 아이콘을 렌더링할 수 있는 새로운 IconButton 컴포넌트를 도입하여, 스타일과 속성을 사용자 정의할 수 있습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a new IconButton component that allows rendering of Material UI icons within a button element, with customizable styles and properties.

</details>