### PR TITLE
[Feature] 404 페이지 퍼블리싱

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import catImage from '@/public/images/cat-404.png'
+
+const NotFoundPage = () => {
+  return (
+    <main className="text-center">
+      <h1 className="mt-[120px] text-xl">페이지를 찾을 수 없습니다.</h1>
+      <Image
+        src={catImage}
+        alt="404 고양이"
+        width={100}
+        height={100}
+        className="mx-auto my-[60px]"
+      />
+      <p className="mx-auto w-[280px] font-galmuri text-lg">
+        찾으시는 페이지가 파도를 타고 멀리 떠난 것 같아요. 괜찮아요! 아래 버튼을 눌러 게임 시작
+        지점으로 안전하게 돌아가세요.
+      </p>
+      <Link
+        href="/"
+        className="fixed bottom-[105px] left-[50%] flex h-[54px] w-[300px] translate-x-[-50%] items-center justify-center rounded-xl bg-primary text-lg text-white"
+      >
+        홈으로 돌아가기
+      </Link>
+    </main>
+  )
+}
+
+export default NotFoundPage

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
+import LinkButton from '@/components/ui/link-button'
 import catImage from '@/public/images/cat-404.png'
 
 const NotFoundPage = () => {
@@ -18,12 +19,9 @@ const NotFoundPage = () => {
         찾으시는 페이지가 파도를 타고 멀리 떠난 것 같아요. 괜찮아요! 아래 버튼을 눌러 게임 시작
         지점으로 안전하게 돌아가세요.
       </p>
-      <Link
-        href="/"
-        className="fixed bottom-[105px] left-[50%] flex h-[54px] w-[300px] translate-x-[-50%] items-center justify-center rounded-xl bg-primary text-lg text-white"
-      >
+      <LinkButton href="/" className="fixed bottom-[105px] left-[50%] translate-x-[-50%]">
         홈으로 돌아가기
-      </Link>
+      </LinkButton>
     </main>
   )
 }

--- a/components/ui/link-button.tsx
+++ b/components/ui/link-button.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react'
+
+import Link from 'next/link'
+import { twMerge } from 'tailwind-merge'
+
+interface LinkButtonProps {
+  href: string
+  children: ReactNode
+  className?: string
+}
+
+const LinkButton = ({ href, children, className }: LinkButtonProps) => {
+  return (
+    <Link
+      href={href}
+      className={twMerge(
+        'flex h-[54px] w-[300px] items-center justify-center rounded-xl bg-primary text-lg text-white',
+        className
+      )}
+    >
+      {children}
+    </Link>
+  )
+}
+
+export default LinkButton


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

404 페이지 퍼블리싱 작업했습니다!
홈으로 돌아가기는 버튼 대신 `Link` 태그를 사용해 만들었습니다.
버튼으로 만들어 onClick 이벤트 핸들러를 사용하는 경우 useRouter 훅을 사용해야돼서 클라이언트 컴포넌트로 만들어야되는데, 
`Link`로 구현하면 서버 컴포넌트로 사용 가능해서`Link` 태그로 구현했습니다 ㅎㅎ

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="391" alt="image" src="https://github.com/user-attachments/assets/5d6afe3d-d094-4464-a96e-0d9f40d57b04">

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

새로운 기능:
- 사용자 친화적인 메시지와 홈페이지로 돌아가는 링크가 포함된 맞춤형 404 오류 페이지 구현.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Implement a custom 404 error page with a user-friendly message and a link to return to the homepage.

</details>