### PR TITLE
[Feature] 일수 선택 페이지 퍼블리싱

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,27 +1,24 @@
 import Image from 'next/image'
-import Link from 'next/link'
 
 import LinkButton from '@/components/ui/link-button'
 import catImage from '@/public/images/cat-404.png'
 
 const NotFoundPage = () => {
   return (
-    <main className="text-center">
-      <h1 className="mt-[120px] text-xl">페이지를 찾을 수 없습니다.</h1>
+    <main className="flex min-h-dvh flex-col items-center justify-center">
+      <h1 className="text-xl">페이지를 찾을 수 없습니다.</h1>
       <Image
         src={catImage}
         alt="404 고양이"
         width={100}
         height={100}
-        className="mx-auto my-[60px]"
+        className="mx-auto my-[50px]"
       />
-      <p className="mx-auto w-[280px] font-galmuri text-lg">
+      <p className="mx-auto mb-20 w-[280px] text-center font-galmuri text-lg">
         찾으시는 페이지가 파도를 타고 멀리 떠난 것 같아요. 괜찮아요! 아래 버튼을 눌러 게임 시작
         지점으로 안전하게 돌아가세요.
       </p>
-      <LinkButton href="/" className="fixed bottom-[105px] left-[50%] translate-x-[-50%]">
-        홈으로 돌아가기
-      </LinkButton>
+      <LinkButton href="/">홈으로 돌아가기</LinkButton>
     </main>
   )
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,7 +5,7 @@ import catImage from '@/public/images/cat-404.png'
 
 const NotFoundPage = () => {
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center">
+    <main className="flex min-h-dvh flex-col items-center justify-center px-3 text-center">
       <h1 className="text-xl">페이지를 찾을 수 없습니다.</h1>
       <Image
         src={catImage}
@@ -14,7 +14,7 @@ const NotFoundPage = () => {
         height={100}
         className="mx-auto my-[50px]"
       />
-      <p className="mx-auto mb-20 w-[280px] text-center font-galmuri text-lg">
+      <p className="mx-auto mb-20 max-w-[280px] text-center font-galmuri text-lg">
         찾으시는 페이지가 파도를 타고 멀리 떠난 것 같아요. 괜찮아요! 아래 버튼을 눌러 게임 시작
         지점으로 안전하게 돌아가세요.
       </p>

--- a/app/setup/select-days/page.tsx
+++ b/app/setup/select-days/page.tsx
@@ -1,15 +1,35 @@
-import React from 'react'
+'use client'
+
+import { useState } from 'react'
 
 import LinkButton from '@/components/ui/link-button'
+import RadioGroup, { RadioButton } from '@/components/ui/radio'
+import { DAY_OPTIONS } from '@/constants/game'
 
-const SelectDaysPage = ({ params }) => {
-  const { gameId = 'N09C14' } = params
+const SelectDaysPage = () => {
+  const gameId = 'N09C14'
+  const [selectedDay, setSelectedDay] = useState(DAY_OPTIONS[0])
+
+  const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedDay(event.target.value)
+  }
 
   return (
-    <>
-      <h2>일수선책</h2>
+    <main className="flex min-h-dvh flex-col items-center justify-center">
+      <h1 className="text-center text-xl">시장에서 거래할 일수를 정해주세요.</h1>
+      <RadioGroup className="my-20">
+        {DAY_OPTIONS.map((day) => (
+          <RadioButton
+            key={day}
+            name="select-days"
+            label={day}
+            isChecked={day === selectedDay}
+            onChangeInput={handleChangeInput}
+          />
+        ))}
+      </RadioGroup>
       <LinkButton href={`/setup/user-info/${gameId}`}>다음</LinkButton>
-    </>
+    </main>
   )
 }
 

--- a/app/setup/select-days/page.tsx
+++ b/app/setup/select-days/page.tsx
@@ -16,7 +16,7 @@ const SelectDaysPage = () => {
 
   return (
     <main className="flex min-h-dvh flex-col items-center justify-center">
-      <h1 className="text-center text-xl">시장에서 거래할 일수를 정해주세요.</h1>
+      <h1 className="px-3 text-center text-xl">시장에서 거래할 일수를 정해주세요.</h1>
       <RadioGroup className="my-20">
         {DAY_OPTIONS.map((day) => (
           <RadioButton

--- a/components/ui/radio.tsx
+++ b/components/ui/radio.tsx
@@ -1,0 +1,57 @@
+import clsx from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+interface RadioButtonProps {
+  name: string
+  label: string
+  isChecked: boolean
+  className?: string
+  onChangeInput: (event: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+interface RadioGroupProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export const RadioButton = ({
+  name,
+  label,
+  isChecked,
+  className,
+  onChangeInput,
+}: RadioButtonProps) => {
+  const radioButtonClassName = twMerge(
+    clsx(
+      'flex h-[54px] w-[190px] cursor-pointer items-center justify-center rounded-xl border-2 border-solid border-primary text-lg',
+      {
+        'bg-primary text-white': isChecked,
+        'bg-white text-black': !isChecked,
+      },
+      className
+    )
+  )
+
+  return (
+    <div>
+      <input
+        type="radio"
+        id={label}
+        name={name}
+        value={label}
+        checked={isChecked}
+        onChange={onChangeInput}
+        className="hidden"
+      />
+      <label htmlFor={label} className={radioButtonClassName}>
+        {label}
+      </label>
+    </div>
+  )
+}
+
+const RadioGroup = ({ className, children }: RadioGroupProps) => {
+  return <div className={twMerge('flex flex-col items-center gap-3', className)}>{children}</div>
+}
+
+export default RadioGroup

--- a/constants/game.ts
+++ b/constants/game.ts
@@ -5,4 +5,7 @@ export const GAME_GUIDE_STEPS = [
   '시장에서 대한 힌트가 주어지지만, 100% 정확하지는 않으니 주의하세요!',
   '최종적으로 가장 많은 냥코인을 모은 플레이어가 우승합니다.',
 ]
+
 export const GAME_GUIDE_COMMENT = '최적의 타이밍에 거래해서 우승을 차지하세요!'
+
+export const DAY_OPTIONS = ['10일', '15일', '20일']


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

일수 선택 페이지 퍼블리싱 작업했습니다

## 🔧 변경 사항

- RadioGroup, RadioButton 컴포넌트 추가
- 일수 선택 페이지 퍼블리싱
- 404 페이지 스타일 수정 (중앙 정렬으로)

## 📸 스크린샷 (선택 사항)

<img width="425" alt="image" src="https://github.com/user-attachments/assets/23943d06-4867-432f-af1f-4779d3b0c923">

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

RadioGroup 및 RadioButton 구성 요소를 사용하여 일수를 선택하는 새 페이지를 추가하고, 요소를 중앙에 배치하여 404 페이지의 스타일을 개선합니다.

새로운 기능:
- RadioGroup 및 RadioButton 구성 요소를 사용하여 일수를 선택하는 새 페이지 구현.

개선 사항:
- 요소를 중앙에 배치하여 404 페이지의 스타일을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new page for selecting the number of days using RadioGroup and RadioButton components, and enhance the styling of the 404 page by centering its elements.

New Features:
- Implement a new page for selecting the number of days with a RadioGroup and RadioButton components.

Enhancements:
- Refactor the 404 page to improve styling by centering elements.

</details>