### PR TITLE
[Feature] playerId uuid로 생성

### DIFF
--- a/types/game.ts
+++ b/types/game.ts
@@ -53,3 +53,6 @@ export interface HintModel {
     low: string
   }
 }
+
+export type SocketIdType = string
+export type PlayerIdType = string


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

보안을 위해 playerId를 socket.id 대신 uuid를 통해 생성하는 방식으로 수정했습니다

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

보안 강화를 위해 playerId 생성 방법을 socket.id에서 UUID로 변경합니다. 새로 생성된 player ID와 소켓 ID를 연결하는 매핑 시스템을 구현하여 플레이어 세션이 안전하고 효율적으로 관리되도록 합니다.

새로운 기능:
- 보안 강화를 위해 UUID를 사용한 새로운 playerId 생성 메커니즘 도입.

개선 사항:
- 플레이어 세션을 더 안전하게 관리하기 위해 소켓 ID와 플레이어 ID 간의 매핑 추가.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the playerId generation method from using socket.id to UUIDs to improve security. Implement a mapping system to associate socket IDs with the newly generated player IDs, ensuring that player sessions are managed securely and efficiently.

New Features:
- Introduce a new playerId generation mechanism using UUIDs for enhanced security.

Enhancements:
- Add a mapping between socket IDs and player IDs to manage player sessions more securely.

</details>