### PR TITLE
[Bug] 올바른 gameId를 입력해도 새로운 방이 생성되는 오류 해결

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ const HomePage = () => {
   const [errorMessage, setErrorMessage] = useState('')
 
   const setGameId = useGameStore((state) => state.setGameId)
+  const setIsLeader = useGameStore((state) => state.setIsLeader)
 
   useEffect(() => {
     const handleSocketConnect = () => {
@@ -67,6 +68,7 @@ const HomePage = () => {
     socket.on('is_available_game', ({ isAvailable, message }) => {
       if (isAvailable) {
         setGameId(inputGameId)
+        setIsLeader(false)
         router.push('/setup/user-info')
       } else {
         setErrorMessage(message)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 원인: `isLeader`의 값이 초기화되지 않아서 올바른 id를 입력해도 Leader로 인식돼 새로운 방을 생성하게 됨
- 해결: 올바른 gameId를 입력했을 때 store의 gameId 뿐만 아니라 isLeader 값도 업데이트

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

버그 수정:
- isLeader 값이 적절하게 업데이트되도록 하여 올바른 gameId가 있어도 새로운 게임 방이 생성되는 문제를 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the issue where a new game room was created even with a correct gameId by ensuring the isLeader value is updated appropriately.

</details>