### PR TITLE
[Fix] 두 번째 게임 힌트 세팅 및 라운드 진행 소켓 관련 문제

### DIFF
--- a/constants/game.ts
+++ b/constants/game.ts
@@ -14,7 +14,7 @@ export const gameConfig = {
   INITIAL_COINS: 1000,
   INITIAL_FISH: 0,
   INITIAL_FISH_PRICE: 100,
-  INITIAL_TIMER: 20,
+  INITIAL_TIMER: 2,
 }
 
 export const PRICE_THRESHOLD = {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

1. 게임 재시작 시 힌트 초기화 및 설정 로직 변경
    - 게임 생성 시가 아닌 게임 시작 시점에 힌트 초기화하도록 수정
    - `start_game` 이벤트에서 힌트 및 게임 정보 초기화 로직 추가
    - `create_game`에서 최소한의 초기 설정만 하도록 수정
    - `check_game_availability`에서 불필요한 초기화 로직 제거

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.