### PR TITLE
[Feat] 실시간 소켓 연결 상태 관리 및 토스트 알림 시스템 구현

### DIFF
--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -11,6 +11,8 @@ import {
   MdArrowRight,
   MdClose,
   MdCheckCircle,
+  MdOutlineWifi,
+  MdOutlineWifiOff,
 } from 'react-icons/md'
 
 export const TrendingFlatIcon = MdOutlineTrendingFlat
@@ -25,3 +27,5 @@ export const ArrowLeftIcon = MdArrowLeft
 export const ArrowRightIcon = MdArrowRight
 export const CloseIcon = MdClose
 export const CheckCircleIcon = MdCheckCircle
+export const WifiIcon = MdOutlineWifi
+export const WifiOffIcon = MdOutlineWifiOff

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -9,9 +9,12 @@ import ErrorModal from '@/components/ui/error-modal'
 import { SOCKET_ERROR_MESSAGES, SOCKET_ERROR_TYPES, SocketErrorType } from '@/constants/socket'
 import useToastStore from '@/store/toast'
 
+const RECONNECT_NOTIFICATION_INTERVAL = 1000
+const ERROR_MODAL_TIMEOUT = 10000
+
 interface SocketContextModel {
   socket: Socket | null
-  isConnected: boolean
+  isSocketConnected: boolean
 }
 
 export const SocketContext = createContext<SocketContextModel | null>(null)
@@ -19,35 +22,36 @@ export const SocketContext = createContext<SocketContextModel | null>(null)
 const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
   const { showToast } = useToastStore()
+
   const [socket, setSocket] = useState<Socket | null>(null)
-  const [isConnected, setIsConnected] = useState(false)
+  const [isSocketConnected, setIsSocketConnected] = useState(false)
+  const [isNetworkOffline, setIsNetworkOffline] = useState(false)
   const [errorType, setErrorType] = useState<SocketErrorType | null>(null)
+
   const wasEverConnected = useRef(false)
-
   const disconnectedAtRef = useRef<number | null>(null)
-
   const errorModalTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const reconnectIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const shouldShowErrorModal = useRef(false)
 
   const handleSocketConnect = () => {
     disconnectedAtRef.current = null
+    setIsNetworkOffline(false)
+    shouldShowErrorModal.current = false
 
-    if (errorModalTimerRef.current) {
-      clearTimeout(errorModalTimerRef.current)
-      errorModalTimerRef.current = null
-    }
-
+    clearTimers()
     setErrorType(null)
 
-    if (wasEverConnected.current && !isConnected) {
+    if (wasEverConnected.current && !isSocketConnected) {
       showToast('서버에 다시 연결되었습니다', 'connection')
     }
 
-    setIsConnected(true)
+    setIsSocketConnected(true)
     wasEverConnected.current = true
   }
 
   const handleSocketDisconnect = () => {
-    setIsConnected(false)
+    setIsSocketConnected(false)
 
     if (disconnectedAtRef.current === null) {
       disconnectedAtRef.current = Date.now()
@@ -55,41 +59,171 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
     if (wasEverConnected.current) {
       showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
+      setIsNetworkOffline(true)
+      shouldShowErrorModal.current = true
+
+      if (errorModalTimerRef.current) {
+        clearTimeout(errorModalTimerRef.current)
+      }
 
       errorModalTimerRef.current = setTimeout(() => {
-        if (!isConnected) {
+        if (shouldShowErrorModal.current) {
           setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
+
+          if (reconnectIntervalRef.current) {
+            clearInterval(reconnectIntervalRef.current)
+            reconnectIntervalRef.current = null
+          }
         }
-      }, 10000)
+      }, ERROR_MODAL_TIMEOUT)
     }
   }
 
+  const handleConnectionError = () => {
+    if (wasEverConnected.current) {
+      setIsNetworkOffline(true)
+      shouldShowErrorModal.current = true
+      showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
+
+      if (errorModalTimerRef.current) {
+        clearTimeout(errorModalTimerRef.current)
+      }
+
+      errorModalTimerRef.current = setTimeout(() => {
+        if (shouldShowErrorModal.current) {
+          setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
+
+          if (reconnectIntervalRef.current) {
+            clearInterval(reconnectIntervalRef.current)
+            reconnectIntervalRef.current = null
+          }
+        }
+      }, ERROR_MODAL_TIMEOUT)
+    }
+  }
+
+  const clearTimers = () => {
+    if (reconnectIntervalRef.current) {
+      clearInterval(reconnectIntervalRef.current)
+      reconnectIntervalRef.current = null
+    }
+
+    if (errorModalTimerRef.current) {
+      clearTimeout(errorModalTimerRef.current)
+      errorModalTimerRef.current = null
+    }
+  }
+
+  // 네트워크 상태 관리
   useEffect(() => {
-    const socketInstance = io()
+    const handleOnline = () => {
+      setIsNetworkOffline(false)
+      shouldShowErrorModal.current = false
+
+      if (errorModalTimerRef.current) {
+        clearTimeout(errorModalTimerRef.current)
+        errorModalTimerRef.current = null
+      }
+
+      if (socket && !socket.connected && wasEverConnected.current) {
+        socket.connect()
+      }
+    }
+
+    const handleOffline = () => {
+      setIsNetworkOffline(true)
+      shouldShowErrorModal.current = true
+
+      if (wasEverConnected.current) {
+        showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
+
+        if (errorModalTimerRef.current) {
+          clearTimeout(errorModalTimerRef.current)
+        }
+
+        errorModalTimerRef.current = setTimeout(() => {
+          if (shouldShowErrorModal.current) {
+            setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
+
+            if (reconnectIntervalRef.current) {
+              clearInterval(reconnectIntervalRef.current)
+              reconnectIntervalRef.current = null
+            }
+          }
+        }, ERROR_MODAL_TIMEOUT)
+      }
+    }
+
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [socket, showToast])
+
+  // 재연결 알람 관리
+  useEffect(() => {
+    if (isNetworkOffline && wasEverConnected.current && !errorType) {
+      if (reconnectIntervalRef.current) {
+        clearInterval(reconnectIntervalRef.current)
+      }
+
+      reconnectIntervalRef.current = setInterval(() => {
+        if (!errorType) {
+          showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
+        }
+      }, RECONNECT_NOTIFICATION_INTERVAL)
+    } else if ((!isNetworkOffline || errorType) && reconnectIntervalRef.current) {
+      clearInterval(reconnectIntervalRef.current)
+      reconnectIntervalRef.current = null
+    }
+
+    return () => {
+      if (reconnectIntervalRef.current) {
+        clearInterval(reconnectIntervalRef.current)
+      }
+    }
+  }, [isNetworkOffline, showToast, errorType])
+
+  // Socket 초기화
+  useEffect(() => {
+    const socketInstance = io({
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      timeout: 5000,
+    })
 
     socketInstance.on('connect', handleSocketConnect)
     socketInstance.on('disconnect', handleSocketDisconnect)
+    socketInstance.on('connect_error', handleConnectionError)
 
     setSocket(socketInstance)
-    setIsConnected(socketInstance.connected)
+    setIsSocketConnected(socketInstance.connected)
 
     if (!socketInstance.connected) {
       socketInstance.connect()
     }
 
     return () => {
-      if (errorModalTimerRef.current) {
-        clearTimeout(errorModalTimerRef.current)
-      }
+      clearTimers()
 
       socketInstance.off('connect', handleSocketConnect)
       socketInstance.off('disconnect', handleSocketDisconnect)
+      socketInstance.off('connect_error')
       socketInstance.disconnect()
     }
   }, [showToast])
 
+  const handleErrorModalClose = () => {
+    setErrorType(null)
+    shouldShowErrorModal.current = false
+    router.push('/')
+  }
+
   return (
-    <SocketContext.Provider value={{ socket, isConnected }}>
+    <SocketContext.Provider value={{ socket, isSocketConnected }}>
       {children}
       {errorType && (
         <ErrorModal
@@ -97,10 +231,7 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
           title={SOCKET_ERROR_MESSAGES[errorType].title}
           message={SOCKET_ERROR_MESSAGES[errorType].message}
           buttonText="홈으로 이동"
-          onClick={() => {
-            setErrorType(null)
-            router.push('/')
-          }}
+          onClick={handleErrorModalClose}
         />
       )}
     </SocketContext.Provider>

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useEffect, useRef, useState } from 'react'
 
 import { useRouter } from 'next/navigation'
 import { Socket, io } from 'socket.io-client'
 
 import ErrorModal from '@/components/ui/error-modal'
 import { SOCKET_ERROR_MESSAGES, SOCKET_ERROR_TYPES, SocketErrorType } from '@/constants/socket'
+import useToastStore from '@/store/toast'
 
 interface SocketContextModel {
   socket: Socket | null
@@ -17,22 +18,54 @@ export const SocketContext = createContext<SocketContextModel | null>(null)
 
 const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
+  const { showToast } = useToastStore()
   const [socket, setSocket] = useState<Socket | null>(null)
   const [isConnected, setIsConnected] = useState(false)
   const [errorType, setErrorType] = useState<SocketErrorType | null>(null)
+  const wasEverConnected = useRef(false)
+
+  const disconnectedAtRef = useRef<number | null>(null)
+
+  const errorModalTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const handleSocketConnect = () => {
+    disconnectedAtRef.current = null
+
+    if (errorModalTimerRef.current) {
+      clearTimeout(errorModalTimerRef.current)
+      errorModalTimerRef.current = null
+    }
+
+    setErrorType(null)
+
+    if (wasEverConnected.current && !isConnected) {
+      showToast('서버에 다시 연결되었습니다', 'connection')
+    }
+
+    setIsConnected(true)
+    wasEverConnected.current = true
+  }
+
+  const handleSocketDisconnect = () => {
+    setIsConnected(false)
+
+    if (disconnectedAtRef.current === null) {
+      disconnectedAtRef.current = Date.now()
+    }
+
+    if (wasEverConnected.current) {
+      showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
+
+      errorModalTimerRef.current = setTimeout(() => {
+        if (!isConnected) {
+          setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
+        }
+      }, 10000)
+    }
+  }
 
   useEffect(() => {
     const socketInstance = io()
-
-    const handleSocketConnect = () => {
-      setIsConnected(true)
-      setErrorType(null)
-    }
-
-    const handleSocketDisconnect = () => {
-      setIsConnected(false)
-      setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
-    }
 
     socketInstance.on('connect', handleSocketConnect)
     socketInstance.on('disconnect', handleSocketDisconnect)
@@ -45,11 +78,15 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     return () => {
+      if (errorModalTimerRef.current) {
+        clearTimeout(errorModalTimerRef.current)
+      }
+
       socketInstance.off('connect', handleSocketConnect)
       socketInstance.off('disconnect', handleSocketDisconnect)
       socketInstance.disconnect()
     }
-  }, [])
+  }, [showToast])
 
   return (
     <SocketContext.Provider value={{ socket, isConnected }}>

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import { twMerge } from 'tailwind-merge'
 
-import { CheckCircleIcon } from '@/components/icons'
+import { CheckCircleIcon, ErrorOutlineIcon, WifiIcon, WifiOffIcon } from '@/components/icons'
 import useToastStore from '@/store/toast'
 import { ToastIconType } from '@/types/ui-types'
 
@@ -19,14 +19,14 @@ interface IconConfigModel {
   [key: string]: string | React.ReactNode
 }
 
-// 토스트 아이콘 설정 객체
-// coin: 코인 아이콘 이미지 경로 | check: 체크 아이콘 컴포넌트
 const iconConfig: IconConfigModel = {
   coin: '/images/coin.png',
   check: <CheckCircleIcon className="text-white" size={24} />,
+  connection: <WifiIcon className="text-white" size={24} />,
+  warning: <ErrorOutlineIcon className="text-yellow-400" size={24} />,
+  offline: <WifiOffIcon className="text-red-500" size={24} />,
 }
 
-// 토스트 아이콘 컴포넌트
 const ToastIcon = ({ icon, className }: ToastIconProps) => {
   const iconContent = iconConfig[icon] || ''
 
@@ -45,7 +45,6 @@ const ToastIcon = ({ icon, className }: ToastIconProps) => {
   return <div className={className}>{iconContent}</div>
 }
 
-// 토스트 전체 컴포넌트
 const Toast = ({ className = '' }: ToastProps) => {
   const { isVisible, message, icon } = useToastStore()
 

--- a/types/ui-types.ts
+++ b/types/ui-types.ts
@@ -1,1 +1,1 @@
-export type ToastIconType = 'coin' | 'check' // 아이콘 종류
+export type ToastIconType = 'coin' | 'check' | 'connection' | 'warning' | 'offline'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

### **연결 상태 관리 명확화**
- 기존 `isConnected` → `isSocketConnected`(실시간 소켓 연결 상태) + `isNetworkOffline`(네트워크 상태)로 분리
- 네트워크 연결과 소켓 연결을 독립적으로 관리하여 개발 과정에서 연결 상태 혼동 방지

### **토스트 알림 기능 추가**
- 소켓 재연결 성공: "서버에 다시 연결되었습니다" (`connection` 타입)
- 연결 불안정 상황: "연결이 불안정합니다. 다시 연결 중..." (`warning` 타입, 1초 간격 반복)

### **에러 처리 개선**
- 10초 이상 연결되지 않을 경우 에러 모달 표시
- socket-provider 파일에서 소켓 연결 실패 및 네트워크 오프라인 상황 통합 처리

### **재연결 로직 강화**
- 브라우저 `online`/`offline` 이벤트와 소켓 재연결 연동
- 무한 재연결 시도로 연결 안정성 향상
- 타이머 기반 알림 관리로 불필요한 중복 토스트 방지
- 연결 히스토리 추적(`wasEverConnected`)으로 초기 연결과 재연결 구분하여 불필요한 초기 알림 방지

### **타이머 관리 최적화**
메모리 누수 방지 및 중복 타이머 정리를 위한 체계적인 리소스 관리

| 변수 | 용도 | 리소스 정리 |
|------|------|-------------|
| errorModalTimerRef | 에러 모달 표시 지연 타이머 | clearTimeout() |
| reconnectIntervalRef | 재연결 토스트 반복 타이머 | clearInterval() |
| disconnectedAtRef | 연결 끊긴 시간 기록 | null로 초기화 |
| shouldShowErrorModal | 에러 모달 중복 표시 방지 | false로 재설정 |


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![May-23-2025 00-34-00](https://github.com/user-attachments/assets/50962889-5296-4216-9907-b5fc0dfb4505)
![May-23-2025 00-34-25](https://github.com/user-attachments/assets/69f76e9d-79ad-4427-baa9-307da101a356)


## 📄 기타
### 현재 소켓 연결 상태 관리 시스템을 기반으로 게임 내 실시간 상태 동기화 최적화 진행 예정

## Sourcery 요약

소켓 및 네트워크 상태를 분리하고, 연결 이벤트에 대한 사용자 알림(toast)을 도입하고, 오류 모달 처리를 통해 재연결 로직을 강화하여 실시간 소켓 연결 관리를 개선합니다.

새로운 기능:
- 연결 상태를 소켓 연결됨(socket-connected) 및 네트워크 오프라인(network-offline) 플래그로 분리
- 성공적인 재연결 및 불안정한 연결에 대한 알림(toast) 추가
- 10초 타임아웃 후 재연결에 실패하면 오류 모달 표시

개선 사항:
- 자동 소켓 재연결을 위해 브라우저 온라인/오프라인 이벤트 활용
- 중복 알림(toast)을 방지하기 위해 타이머 기반 정리(cleanup)를 통해 소켓 이벤트 처리 중앙 집중화
- 불필요한 초기 알림을 억제하기 위해 연결 기록 플래그 사용
- 알림(toast) 아이콘 세트에 wifi 및 경고 아이콘 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve real-time socket connection management by separating socket and network statuses, introducing user-facing toasts for connection events, and strengthening reconnection logic with error modal handling.

New Features:
- Separate connection state into socket-connected and network-offline flags
- Add toast notifications for successful reconnection and unstable connections
- Show an error modal if reconnection fails after a 10-second timeout

Enhancements:
- Leverage browser online/offline events for automatic socket reconnection
- Centralize socket event handling with timer-based cleanup to prevent duplicate toasts
- Use a connection history flag to suppress unnecessary initial notifications
- Extend the toast icon set with wifi and warning icons

</details>