### PR TITLE
[feat]게임 재연결 및 상태 동기화 시스템 구현

### DIFF
--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -25,6 +25,7 @@ import {
   TransactionType,
   HintContentModel,
   GameResultModel,
+  GameInfoModel,
 } from '@/types/game'
 
 const GamePage = ({ params }) => {
@@ -65,60 +66,6 @@ const GamePage = ({ params }) => {
   const { socket } = useSocket()
 
   useEffect(() => {
-    const handlePlayerInitialize = ({
-      players,
-      playerId,
-    }: {
-      players: PlayerModel[]
-      playerId: string
-    }) => {
-      setPlayers(players)
-      setPlayerId(playerId)
-    }
-
-    const handlePlayersUpdate = (updatedPlayers: PlayerModel[]) => {
-      setPlayers(updatedPlayers)
-    }
-
-    const handleFirstRoundHint = (gameInfo) => {
-      if (gameInfo.currentDay === 1) {
-        setHints({
-          nextRoundHint: gameInfo.nextRoundHint,
-          lastRoundHintResult: '',
-        })
-      }
-    }
-
-    const handleLastFishPrice = (newPrice) => {
-      setLastFishCoin(newPrice)
-      setGameState((prev) => ({ ...prev, isModalOpen: true }))
-    }
-
-    const handleTradeMessage = (result: TransactionResultModel) => {
-      setTransactionResult(result)
-    }
-
-    const handleGameInfoUpdate = (gameInfo) => {
-      setPrevFishPrice(gameState.fishPrice)
-      setGameState((prev) => ({
-        ...prev,
-        fishPrice: gameInfo.currentFishPrice,
-        currentRound: gameInfo.currentDay,
-      }))
-      setHints({
-        nextRoundHint: gameInfo.nextRoundHint || '',
-        lastRoundHintResult: gameInfo.lastRoundHintResult || '',
-      })
-    }
-
-    const handleGameEnded = ({ results }: { results: GameResultModel[] }) => {
-      setGameResults(results)
-    }
-
-    socket.emit('request_player_info', { gameId })
-    socket.emit('request_first_round_hint', { gameId })
-    socket.emit('player_ready', { gameId })
-
     socket.on('player_info', handlePlayerInitialize)
     socket.on('update_players', handlePlayersUpdate)
     socket.on('first_round_hint', handleFirstRoundHint)
@@ -126,6 +73,17 @@ const GamePage = ({ params }) => {
     socket.on('trade_message', handleTradeMessage)
     socket.on('update_game_info', handleGameInfoUpdate)
     socket.on('game_ended', handleGameEnded)
+    socket.on('round_sync', handleRoundSync)
+    socket.on('reconnect', handleReconnect)
+    socket.on('disconnect', handleDisconnect)
+    socket.on('sync_complete', handleGameSync)
+    socket.on('complete_round_sync', handleGameSync)
+
+    // 초기 요청
+    console.log('🚀 초기 게임 정보 요청:', { gameId })
+    socket.emit('request_player_info', { gameId })
+    socket.emit('request_first_round_hint', { gameId })
+    socket.emit('player_ready', { gameId })
 
     return () => {
       socket.off('player_info')
@@ -135,12 +93,43 @@ const GamePage = ({ params }) => {
       socket.off('trade_message')
       socket.off('update_game_info')
       socket.off('game_ended')
+      socket.off('round_sync')
+      socket.off('reconnect')
+      socket.off('disconnect')
+      socket.off('sync_complete')
+      socket.off('complete_round_sync')
     }
   }, [gameId])
 
   useEffect(() => {
     resetResults()
   }, [])
+
+  const updateHintsAndGameState = (gameInfo: GameInfoModel, source: string) => {
+    console.log(`🎯 힌트 및 게임 상태 업데이트 (${source}):`, gameInfo)
+    if (gameInfo.currentFishPrice && gameInfo.currentFishPrice !== gameState.fishPrice) {
+      setPrevFishPrice(gameState.fishPrice)
+    }
+
+    if (gameInfo.nextRoundHint !== undefined || gameInfo.lastRoundHintResult !== undefined) {
+      setHints((prev) => ({
+        nextRoundHint:
+          gameInfo.nextRoundHint !== undefined ? gameInfo.nextRoundHint : prev.nextRoundHint,
+        lastRoundHintResult:
+          gameInfo.lastRoundHintResult !== undefined
+            ? gameInfo.lastRoundHintResult
+            : prev.lastRoundHintResult,
+      }))
+    }
+
+    if (gameInfo.currentFishPrice !== undefined || gameInfo.currentDay !== undefined) {
+      setGameState((prev) => ({
+        ...prev,
+        ...(gameInfo.currentFishPrice !== undefined && { fishPrice: gameInfo.currentFishPrice }),
+        ...(gameInfo.currentDay !== undefined && { currentRound: gameInfo.currentDay }),
+      }))
+    }
+  }
 
   const handleTransaction = (action: TransactionType, amount: number) => {
     setGameState((prevState) => {
@@ -175,6 +164,142 @@ const GamePage = ({ params }) => {
     }
 
     socket.emit('end_game', { gameId, result: finalScore })
+  }
+
+  const handlePlayerInitialize = ({
+    players,
+    playerId,
+  }: {
+    players: PlayerModel[]
+    playerId: string
+  }) => {
+    console.log('🎮 플레이어 초기화:', { players, playerId })
+    setPlayers(players)
+    setPlayerId(playerId)
+
+    if (gameId && playerId) {
+      console.log('🔄 동기화 요청 (playerId 설정 후):', { gameId, playerId })
+      socket.emit('request_sync', {
+        gameId,
+        playerId,
+      })
+    }
+  }
+
+  const handlePlayersUpdate = (updatedPlayers: PlayerModel[]) => {
+    setPlayers(updatedPlayers)
+  }
+
+  const handleFirstRoundHint = (gameInfo) => {
+    console.log('🎯 첫 라운드 힌트 수신:', gameInfo)
+    updateHintsAndGameState(gameInfo, 'firstRoundHint')
+
+    if (gameInfo.currentDay === 1) {
+      setHints({
+        nextRoundHint: gameInfo.nextRoundHint,
+        lastRoundHintResult: '',
+      })
+    }
+  }
+
+  const handleLastFishPrice = (newPrice) => {
+    setLastFishCoin(newPrice)
+    setGameState((prev) => ({ ...prev, isModalOpen: true }))
+  }
+
+  const handleTradeMessage = (result: TransactionResultModel) => {
+    setTransactionResult(result)
+  }
+
+  const handleGameInfoUpdate = (gameInfo) => {
+    console.log('🔄 게임 정보 업데이트:', gameInfo)
+    updateHintsAndGameState(gameInfo, 'updateGameInfo')
+  }
+
+  const handleGameEnded = ({ results }: { results: GameResultModel[] }) => {
+    setGameResults(results)
+  }
+
+  const handleRoundSync = (roundData) => {
+    console.log('🔄 라운드 동기화:', roundData)
+    updateHintsAndGameState(
+      {
+        currentDay: roundData.currentRound,
+        currentFishPrice: roundData.fishPrice,
+        nextRoundHint: roundData.hint,
+        lastRoundHintResult: roundData.lastRoundResult,
+      },
+      'roundSync'
+    )
+  }
+
+  const handleGameSync = (syncData) => {
+    console.log('🔄 게임 상태 동기화 수신:', syncData)
+
+    if (syncData.gameInfo) {
+      const { currentDay, currentFishPrice, nextRoundHint, lastRoundHintResult } = syncData.gameInfo
+
+      console.log('📊 동기화 데이터 적용:', {
+        currentRound: currentDay,
+        fishPrice: currentFishPrice,
+        hint: nextRoundHint,
+        hintResult: lastRoundHintResult,
+      })
+
+      if (currentFishPrice !== undefined && currentFishPrice !== gameState.fishPrice) {
+        setPrevFishPrice(gameState.fishPrice)
+      }
+
+      setGameState((prev) => ({
+        ...prev,
+        currentRound: currentDay || prev.currentRound,
+        fishPrice: currentFishPrice !== undefined ? currentFishPrice : prev.fishPrice,
+      }))
+
+      setHints({
+        nextRoundHint: nextRoundHint || '',
+        lastRoundHintResult: lastRoundHintResult || '',
+      })
+    }
+
+    if (syncData.currentRound !== undefined) {
+      console.log('📊 라운드 동기화:', {
+        currentRound: syncData.currentRound,
+        fishPrice: syncData.fishPrice,
+        hint: syncData.hint,
+        hintResult: syncData.lastRoundResult,
+      })
+
+      if (syncData.fishPrice !== undefined && syncData.fishPrice !== gameState.fishPrice) {
+        setPrevFishPrice(gameState.fishPrice)
+      }
+
+      setGameState((prev) => ({
+        ...prev,
+        currentRound: syncData.currentRound,
+        fishPrice: syncData.fishPrice !== undefined ? syncData.fishPrice : prev.fishPrice,
+      }))
+
+      setHints({
+        nextRoundHint: syncData.hint || '',
+        lastRoundHintResult: syncData.lastRoundResult || '',
+      })
+    }
+
+    if (syncData.players) {
+      setPlayers(syncData.players)
+    }
+  }
+
+  const handleReconnect = () => {
+    console.log('🔄 소켓 재연결됨')
+    socket.emit('request_player_info', { gameId })
+    socket.emit('request_first_round_hint', { gameId })
+    socket.emit('player_ready', { gameId })
+  }
+
+  const handleDisconnect = (reason) => {
+    console.log('🔴 소켓 연결 끊김:', reason)
   }
 
   const totalCoin = gameState.fish * lastFishCoin + gameState.coins

--- a/app/setup/user-info/page.tsx
+++ b/app/setup/user-info/page.tsx
@@ -35,8 +35,8 @@ const UserInfoPage = () => {
   const rounds = useGameStore((state) => state.rounds)
 
   useEffect(() => {
-    const handleJoinSuccess = (gameId: string) => {
-      router.push(`/waiting/${gameId}`)
+    const handleJoinSuccess = (data) => {
+      router.push(`/waiting/${data.gameId}`)
     }
 
     const handleJoinFailure = () => {

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -29,13 +29,71 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const [errorType, setErrorType] = useState<SocketErrorType | null>(null)
 
   const wasEverConnected = useRef(false)
-  const disconnectedAtRef = useRef<number | null>(null)
   const errorModalTimerRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const shouldShowErrorModal = useRef(false)
 
-  const handleSocketConnect = () => {
-    disconnectedAtRef.current = null
+  const reconnectionInProgress = useRef(false)
+  const lastSyncRequestTime = useRef(0)
+  const gameRestoreToastShown = useRef(false)
+
+  const gameDataRef = useRef<{
+    gameId: string | null
+    playerId: string | null
+  }>({
+    gameId: null,
+    playerId: null,
+  })
+
+  const saveGameData = (gameId: string, playerId: string) => {
+    gameDataRef.current = {
+      gameId,
+      playerId,
+    }
+    console.log('💾 게임 데이터 저장됨:', { gameId, playerId })
+  }
+
+  const getGameData = () => {
+    return {
+      gameId: gameDataRef.current.gameId,
+      playerId: gameDataRef.current.playerId,
+    }
+  }
+
+  const handleGameStateSync = (socketInstance: Socket) => {
+    const { gameId, playerId } = getGameData()
+
+    if (reconnectionInProgress.current) {
+      return
+    }
+
+    const now = Date.now()
+    if (now - lastSyncRequestTime.current < 3000) {
+      return
+    }
+
+    if (gameId && playerId && socketInstance.connected) {
+      console.log('📡 게임 상태 동기화 요청 전송됨')
+
+      reconnectionInProgress.current = true
+      lastSyncRequestTime.current = now
+
+      socketInstance.emit('request_sync', {
+        gameId,
+        playerId,
+        timestamp: now,
+      })
+
+      setTimeout(() => {
+        if (reconnectionInProgress.current) {
+          console.log('⏰ 동기화 타임아웃')
+          reconnectionInProgress.current = false
+        }
+      }, 10000)
+    }
+  }
+
+  const handleSocketConnect = (socketInstance: Socket) => {
     setIsNetworkOffline(false)
     shouldShowErrorModal.current = false
 
@@ -44,6 +102,13 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
     if (wasEverConnected.current && !isSocketConnected) {
       showToast('서버에 다시 연결되었습니다', 'connection')
+
+      const { gameId, playerId } = getGameData()
+      if (gameId && playerId) {
+        setTimeout(() => {
+          handleGameStateSync(socketInstance)
+        }, 1000)
+      }
     }
 
     setIsSocketConnected(true)
@@ -52,10 +117,8 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
   const handleSocketDisconnect = () => {
     setIsSocketConnected(false)
-
-    if (disconnectedAtRef.current === null) {
-      disconnectedAtRef.current = Date.now()
-    }
+    reconnectionInProgress.current = false
+    gameRestoreToastShown.current = false
 
     if (wasEverConnected.current) {
       showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
@@ -80,6 +143,8 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   }
 
   const handleConnectionError = () => {
+    reconnectionInProgress.current = false
+
     if (wasEverConnected.current) {
       setIsNetworkOffline(true)
       shouldShowErrorModal.current = true
@@ -114,11 +179,139 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }
 
-  // 네트워크 상태 관리
+  const handleSocketReconnectAttempt = () => {
+    reconnectionInProgress.current = false
+  }
+
+  const handleSocketReconnectSuccess = () => {
+    reconnectionInProgress.current = false
+  }
+
+  const handleSocketReconnectFailed = () => {
+    console.log('❌ 재연결 실패')
+    reconnectionInProgress.current = false
+    if (confirm('재연결에 실패했습니다. 페이지를 새로고침하시겠습니까?')) {
+      window.location.reload()
+    }
+  }
+
+  const handleSyncComplete = (gameSnapshot: any) => {
+    console.log('✅ 게임 상태 동기화 완료')
+
+    reconnectionInProgress.current = false
+    setIsNetworkOffline(false)
+
+    if (!gameRestoreToastShown.current) {
+      showToast('게임 상태가 복원되었습니다', 'connection')
+      gameRestoreToastShown.current = true
+    }
+
+    const { gameId, playerId } = getGameData()
+    if (gameSnapshot.gameId && gameId !== gameSnapshot.gameId) {
+      saveGameData(gameSnapshot.gameId, playerId || '')
+    }
+
+    window.dispatchEvent(
+      new CustomEvent('gameStateRestored', {
+        detail: gameSnapshot,
+      })
+    )
+  }
+
+  const handleSyncFailed = ({ error }: { error: string }, socketInstance: Socket) => {
+    console.log('❌ 동기화 실패:', error)
+    reconnectionInProgress.current = false
+    showToast('게임 상태 복원에 실패했습니다', 'warning')
+
+    const { gameId, playerId } = getGameData()
+    if (gameId && playerId && socketInstance.connected) {
+      setTimeout(() => {
+        if (!reconnectionInProgress.current && socketInstance.connected) {
+          handleGameStateSync(socketInstance)
+        }
+      }, 3000)
+    }
+  }
+
+  const handleJoinSuccess = ({ gameId, playerId }: { gameId: string; playerId: string }) => {
+    saveGameData(gameId, playerId)
+  }
+
+  const handlePlayerNotFound = ({ message }: { message: string }) => {
+    console.log('❌ 플레이어를 찾을 수 없음:', message)
+
+    reconnectionInProgress.current = false
+
+    setTimeout(() => {
+      if (!reconnectionInProgress.current) {
+        gameDataRef.current = {
+          gameId: null,
+          playerId: null,
+        }
+
+        showToast(message, 'warning')
+
+        if (
+          window.location.pathname.includes('/game/') ||
+          window.location.pathname.includes('/waiting/')
+        ) {
+          router.push('/')
+        }
+      }
+    }, 1000)
+  }
+
+  const handleGameStateRestored = (gameState: any) => {
+    reconnectionInProgress.current = false
+    setIsNetworkOffline(false)
+
+    window.dispatchEvent(
+      new CustomEvent('gameStateRestored', {
+        detail: gameState,
+      })
+    )
+  }
+
+  const handlePlayerReconnected = ({ nickname }: { nickname: string }) => {
+    showToast(`${nickname}님이 재연결되었습니다`, 'connection')
+  }
+
+  const setupDebugFunctions = (socketInstance: Socket) => {
+    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+      window.debugSocket = {
+        status: () => {
+          const { gameId, playerId } = getGameData()
+          console.log('🔍 소켓 상태:', {
+            connected: socketInstance.connected,
+            gameId: gameId ? `${gameId.slice(0, 4)}***` : null,
+            playerId: playerId ? `${playerId.slice(0, 8)}***` : null,
+            reconnecting: reconnectionInProgress.current,
+          })
+        },
+        reconnect: () => {
+          console.log('🔧 수동 게임 상태 동기화 시도')
+          if (socketInstance.connected) {
+            reconnectionInProgress.current = false
+            handleGameStateSync(socketInstance)
+          } else {
+            console.log('❌ 소켓이 연결되지 않음')
+          }
+        },
+      }
+    }
+  }
+
+  const cleanupDebugFunctions = () => {
+    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+      delete window.debugSocket
+    }
+  }
+
   useEffect(() => {
     const handleOnline = () => {
       setIsNetworkOffline(false)
       shouldShowErrorModal.current = false
+      reconnectionInProgress.current = false
 
       if (errorModalTimerRef.current) {
         clearTimeout(errorModalTimerRef.current)
@@ -127,12 +320,22 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
       if (socket && !socket.connected && wasEverConnected.current) {
         socket.connect()
+
+        const { gameId, playerId } = getGameData()
+        if (gameId && playerId) {
+          setTimeout(() => {
+            if (socket.connected) {
+              handleGameStateSync(socket)
+            }
+          }, 1500)
+        }
       }
     }
 
     const handleOffline = () => {
       setIsNetworkOffline(true)
       shouldShowErrorModal.current = true
+      reconnectionInProgress.current = false
 
       if (wasEverConnected.current) {
         showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
@@ -163,7 +366,6 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }, [socket, showToast])
 
-  // 재연결 알람 관리
   useEffect(() => {
     if (isNetworkOffline && wasEverConnected.current && !errorType) {
       if (reconnectIntervalRef.current) {
@@ -187,17 +389,36 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }, [isNetworkOffline, showToast, errorType])
 
-  // Socket 초기화
   useEffect(() => {
     const socketInstance = io({
-      reconnectionAttempts: Infinity,
+      reconnection: true,
+      reconnectionAttempts: 10,
       reconnectionDelay: 1000,
-      timeout: 5000,
+      reconnectionDelayMax: 5000,
+      timeout: 15000,
+      forceNew: false,
     })
 
-    socketInstance.on('connect', handleSocketConnect)
-    socketInstance.on('disconnect', handleSocketDisconnect)
-    socketInstance.on('connect_error', handleConnectionError)
+    socketInstance.on('connect', () => {
+      handleSocketConnect(socketInstance)
+    })
+    socketInstance.on('disconnect', (reason) => {
+      console.log('💔 소켓 연결 끊김:', reason)
+      handleSocketDisconnect()
+    })
+    socketInstance.on('connect_error', (error) => {
+      console.log('❌ 연결 에러:', error)
+      handleConnectionError()
+    })
+    socketInstance.on('reconnect_attempt', handleSocketReconnectAttempt)
+    socketInstance.on('reconnect', handleSocketReconnectSuccess)
+    socketInstance.on('reconnect_failed', handleSocketReconnectFailed)
+    socketInstance.on('sync_complete', handleSyncComplete)
+    socketInstance.on('sync_failed', (data) => handleSyncFailed(data, socketInstance))
+    socketInstance.on('join_success', handleJoinSuccess)
+    socketInstance.on('player_not_found', handlePlayerNotFound)
+    socketInstance.on('game_state_restored', handleGameStateRestored)
+    socketInstance.on('player_reconnected', handlePlayerReconnected)
 
     setSocket(socketInstance)
     setIsSocketConnected(socketInstance.connected)
@@ -206,15 +427,28 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       socketInstance.connect()
     }
 
+    setupDebugFunctions(socketInstance)
+
     return () => {
       clearTimers()
 
-      socketInstance.off('connect', handleSocketConnect)
-      socketInstance.off('disconnect', handleSocketDisconnect)
+      socketInstance.off('connect')
+      socketInstance.off('disconnect')
       socketInstance.off('connect_error')
+      socketInstance.off('reconnect_attempt')
+      socketInstance.off('reconnect')
+      socketInstance.off('reconnect_failed')
+      socketInstance.off('sync_complete')
+      socketInstance.off('sync_failed')
+      socketInstance.off('game_state_restored')
+      socketInstance.off('player_reconnected')
+      socketInstance.off('player_not_found')
+      socketInstance.off('join_success')
       socketInstance.disconnect()
+
+      cleanupDebugFunctions()
     }
-  }, [showToast])
+  }, [showToast, router])
 
   const handleErrorModalClose = () => {
     setErrorType(null)

--- a/hooks/use-socket-navigation.ts
+++ b/hooks/use-socket-navigation.ts
@@ -17,8 +17,6 @@ export const useSocketNavigation = (gameId) => {
       socket.emit('leave_game', { gameId })
     }
 
-    socket.removeAllListeners()
-    socket.disconnect()
     router.push('/')
   }
 

--- a/server/game/handlers.ts
+++ b/server/game/handlers.ts
@@ -5,43 +5,27 @@ import { ERROR_NOTICE } from '../../constants/chat.js'
 import { gameConfig } from '../../constants/game.js'
 import { loadGameHints } from '../../lib/api/hints.js'
 import { generateGameId } from '../../lib/utils/generate-game-id.js'
-import { GameModel, PlayerModel } from '../../types/game.js'
+import { GameHistoryModel, GameModel, PlayerModel, RoundRecordModel } from '../../types/game.js'
 
-import { handlePlayerLeave } from './player.js'
+import { getGameHistory } from './history.js'
 import {
   addPlayer,
-  addRoom,
+  getPlayer,
+  getPlayerStatus,
+  handlePlayerLeave,
+  updatePlayerStatus,
+} from './player.js'
+import { addRoom, getRoom } from './room.js'
+import {
+  playersDisconnected,
   gameRooms,
   gameTimers,
-  getPlayerId,
-  getRoom,
+  gameTimersState,
   playersMap,
+  playersReconnecting,
+  playersReconnectingSet,
 } from './store.js'
-import { startGameTimer } from './timer.js'
-
-export const handleCheckGameAvailability = (
-  socket: Socket,
-  { inputGameId: gameId }: { inputGameId: string }
-) => {
-  const room = getRoom(gameId)
-
-  const gameAvailability = {
-    isAvailable: false,
-    message: '',
-  }
-
-  if (!room) {
-    gameAvailability.message = '존재하지 않는 방 코드입니다.'
-  } else if (room.state === 'in_progress' || room.state === 'ended') {
-    gameAvailability.message = '이미 게임이 진행 중인 방입니다.'
-  } else if (room.players.length >= 6) {
-    gameAvailability.message = '방이 가득 찼습니다. (최대 6명)'
-  } else {
-    gameAvailability.isAvailable = true
-  }
-
-  socket.emit('is_available_game', gameAvailability)
-}
+import { startRoundTimer } from './timer.js'
 
 export const handleCreateGame = async (totalRounds: number, joinGame: (gameId: string) => void) => {
   const gameId = generateGameId(gameRooms)
@@ -66,19 +50,58 @@ export const handleCreateGame = async (totalRounds: number, joinGame: (gameId: s
   joinGame(gameId)
 }
 
+export const handleCheckGameAvailability = (
+  socket: Socket,
+  { inputGameId: gameId }: { inputGameId: string }
+) => {
+  const room = getRoom(gameId)
+  const gameAvailability = { isAvailable: false, message: '' }
+
+  if (!room) {
+    gameAvailability.message = '존재하지 않는 방 코드입니다.'
+  } else if (room.state === 'in_progress' || room.state === 'ended') {
+    gameAvailability.message = '이미 게임이 진행 중인 방입니다.'
+  } else if (room.players.length >= 6) {
+    gameAvailability.message = '방이 가득 찼습니다. (최대 6명)'
+  } else {
+    gameAvailability.isAvailable = true
+  }
+
+  socket.emit('is_available_game', gameAvailability)
+}
+
 export const handleJoinGame = (
   socket: Socket,
   { gameId, nickname, character }: { gameId: string; nickname: string; character: string }
 ) => {
   const room = getRoom(gameId)
 
-  if (room) {
-    if (room.state === 'in_progress') {
-      socket.emit('join_failure')
-      return
-    }
-    const playerId = uuid()
+  if (!room) {
+    socket.emit('join_failure', { message: '존재하지 않는 게임입니다.' })
+    return
+  }
+
+  if (room.state === 'in_progress') {
+    socket.emit('join_failure', { message: '이미 게임이 진행 중입니다.' })
+    return
+  }
+
+  if (room.players.length >= 6) {
+    socket.emit('join_failure', { message: '방이 가득 찼습니다.' })
+    return
+  }
+
+  const existingPlayer = room.players.find((p) => p.nickname === nickname)
+  if (existingPlayer) {
+    socket.emit('join_failure', { message: '이미 사용 중인 닉네임입니다.' })
+    return
+  }
+
+  const playerId = uuid()
+
+  try {
     addPlayer(socket.id, playerId)
+    updatePlayerStatus(playerId, true, socket.id)
 
     const newPlayer: PlayerModel = {
       id: playerId,
@@ -87,22 +110,24 @@ export const handleJoinGame = (
       score: 0,
       isInWaitingRoom: true,
     }
+
     room.players.push(newPlayer)
     room.readyPlayers.add(playerId)
-
     socket.join(gameId)
+
     socket.to(gameId).emit('update_players', room.players)
-    socket.emit('join_success', gameId)
+    socket.emit('join_success', { gameId, playerId })
+  } catch (error) {
+    console.error('플레이어 참가 중 오류:', error)
+    socket.emit('join_failure', { message: '게임 참가 중 오류가 발생했습니다.' })
   }
 }
 
-export const handleRequestPlayerInfo = (socket: Socket, { gameId }: { gameId: string }) => {
-  const room = getRoom(gameId)
-  const playerId = getPlayerId(socket.id)
+export const handleLeaveGame = (socket: Socket, { gameId }: { gameId: string }) => {
+  const playerId = getPlayer(socket.id)
+  if (!playerId) return
 
-  if (room) {
-    socket.emit('player_info', { players: room.players, playerId })
-  }
+  handlePlayerLeave(socket, playerId, gameId)
 }
 
 export const handleStartGame = async (
@@ -168,13 +193,13 @@ export const handlePlayerReady = (
   const room = getRoom(gameId)
   if (!room || room.state !== 'in_progress') return
 
-  const playerId = getPlayerId(socket.id)
+  const playerId = getPlayer(socket.id)
   if (!playerId) return
 
   room.readyPlayers.add(playerId)
 
   if (room.readyPlayers.size === room.players.length) {
-    startGameTimer(io, gameId, room)
+    startRoundTimer(io, gameId, room)
     io.to(gameId).emit('all_players_ready')
   }
 }
@@ -251,34 +276,13 @@ export const handleEndGame = (
   }
 }
 
-export const handleRequestFirstRoundHint = (socket: Socket, { gameId }: { gameId: string }) => {
-  const room = getRoom(gameId)
-  if (room) {
-    socket.emit('first_round_hint', room.gameInfo)
-  }
-}
-
-export const handleTradeFishes = (
-  io: SocketIOServer,
-  socket: Socket,
-  { gameId, action, amount }: { gameId: string; action: 'buy' | 'sell'; amount: number }
-) => {
-  const playerId = getPlayerId(socket.id)
-  const message = `${amount}마리 ${action === 'buy' ? '사요!' : '팔아요!'}`
-
-  io.to(gameId).emit('trade_message', {
-    playerId,
-    message,
-  })
-}
-
 export const handleBackToWaiting = (
   io: SocketIOServer,
   socket: Socket,
   { gameId }: { gameId: string }
 ) => {
   const room = getRoom(gameId)
-  const playerId = getPlayerId(socket.id)
+  const playerId = getPlayer(socket.id)
 
   if (!room || !playerId) {
     return
@@ -298,6 +302,22 @@ export const handleBackToWaiting = (
   io.to(gameId).emit('update_players', room.players)
 }
 
+export const handleRequestPlayerInfo = (socket: Socket, { gameId }: { gameId: string }) => {
+  const room = getRoom(gameId)
+  const playerId = getPlayer(socket.id)
+
+  if (room) {
+    socket.emit('player_info', { players: room.players, playerId })
+  }
+}
+
+export const handleRequestFirstRoundHint = (socket: Socket, { gameId }: { gameId: string }) => {
+  const room = getRoom(gameId)
+  if (room) {
+    socket.emit('first_round_hint', room.gameInfo)
+  }
+}
+
 export const handleCheckNotReturnedPlayers = (socket: Socket, { gameId }: { gameId: string }) => {
   const room = getRoom(gameId)
   if (room) {
@@ -306,21 +326,130 @@ export const handleCheckNotReturnedPlayers = (socket: Socket, { gameId }: { game
   }
 }
 
-export const handleLeaveGame = (socket: Socket, { gameId }: { gameId: string }) => {
-  const playerId = getPlayerId(socket.id)
-  if (!playerId) return
+export const handleRequestSync = (
+  io: SocketIOServer,
+  socket: Socket,
+  data: { gameId?: string; playerId?: string; timestamp?: number }
+) => {
+  const { gameId, playerId } = data
 
-  handlePlayerLeave(socket, playerId, gameId)
+  if (!gameId || typeof gameId !== 'string') {
+    socket.emit('sync_failed', {
+      error: 'gameId가 필요합니다.',
+      errorCode: 'INVALID_GAME_ID',
+    })
+    return
+  }
+
+  if (!playerId || typeof playerId !== 'string') {
+    socket.emit('sync_failed', {
+      error: '플레이어 정보가 없습니다. 다시 로그인해주세요.',
+      errorCode: 'INVALID_PLAYER_ID',
+      requireLogin: true,
+    })
+    return
+  }
+
+  const room = getRoom(gameId)
+  if (!room) {
+    socket.emit('sync_failed', {
+      error: '게임을 찾을 수 없습니다.',
+      errorCode: 'GAME_NOT_FOUND',
+    })
+    return
+  }
+
+  const player = room.players.find((p) => p.id === playerId)
+  if (!player) {
+    socket.emit('player_not_found', {
+      gameId,
+      message: '게임에서 제거되었습니다. 다시 참가해주세요.',
+      errorCode: 'PLAYER_NOT_FOUND',
+    })
+    return
+  }
+
+  const reconnectKey = `${gameId}-${playerId}`
+
+  if (playersReconnectingSet.has(reconnectKey)) {
+    const gameHistory = getGameHistory(gameId)
+    const completeGameSnapshot = createCompleteGameSnapshot(room, gameId, gameHistory)
+    socket.emit('sync_complete', completeGameSnapshot)
+    return
+  }
+
+  playersReconnectingSet.add(reconnectKey)
+
+  try {
+    performPlayerReconnection(io, socket, room, gameId, playerId, player)
+  } catch (error) {
+    console.error('재연결 처리 중 오류:', error)
+    socket.emit('sync_failed', {
+      error: '재연결 처리 중 오류가 발생했습니다.',
+      errorCode: 'RECONNECTION_ERROR',
+    })
+  } finally {
+    setTimeout(() => {
+      playersReconnectingSet.delete(reconnectKey)
+    }, 2000)
+  }
+}
+
+export const handleRoundValidationRequest = (
+  socket: Socket,
+  { gameId, clientCurrentRound }: { gameId: string; clientCurrentRound: number }
+) => {
+  const room = getRoom(gameId)
+  const gameHistory = getGameHistory(gameId)
+
+  if (!room || !gameHistory) {
+    socket.emit('round_validation_failed', { error: '게임을 찾을 수 없습니다.' })
+    return
+  }
+
+  const serverCurrentRound = room.gameInfo.currentDay
+
+  if (clientCurrentRound !== serverCurrentRound) {
+    const gameSnapshot = createCompleteGameSnapshot(room, gameId, gameHistory)
+    socket.emit('round_sync_required', gameSnapshot)
+  } else {
+    socket.emit('round_validation_success', { currentRound: serverCurrentRound })
+  }
 }
 
 export const handleDisconnect = (socket: Socket) => {
-  const playerId = getPlayerId(socket.id)
+  const playerId = getPlayer(socket.id)
   if (!playerId) return
 
-  handlePlayerLeave(socket, playerId)
+  if (playersDisconnected.has(playerId)) {
+    const existingTimeout = playersDisconnected.get(playerId)
+    if (existingTimeout) {
+      clearTimeout(existingTimeout)
+    }
+  }
+
+  const timeoutId = setTimeout(() => {
+    handlePlayerLeave(socket, playerId)
+    playersDisconnected.delete(playerId)
+  }, 60000)
+
+  playersDisconnected.set(playerId, timeoutId)
 }
 
-// chat
+export const handleTradeFishes = (
+  io: SocketIOServer,
+  socket: Socket,
+  { gameId, action, amount }: { gameId: string; action: 'buy' | 'sell'; amount: number }
+) => {
+  const playerId = getPlayer(socket.id)
+  const message = `${amount}마리 ${action === 'buy' ? '사요!' : '팔아요!'}`
+
+  io.to(gameId).emit('trade_message', {
+    playerId,
+    message,
+  })
+}
+
 export const handleSendMessage = (
   io: SocketIOServer,
   socket: Socket,
@@ -338,7 +467,7 @@ export const handleSendMessage = (
     message: string
   }
 ) => {
-  const senderId = getPlayerId(socket.id)
+  const senderId = getPlayer(socket.id)
   const room = getRoom(gameId)
 
   if (!senderId || !room) return
@@ -364,4 +493,220 @@ export const handleSendNotice = (
   if (!room) return
 
   io.to(gameId).emit('new_chat_notice', { notice })
+}
+
+const performPlayerReconnection = (
+  io: SocketIOServer,
+  socket: Socket,
+  room: GameModel & { readyPlayers: Set<string> },
+  gameId: string,
+  playerId: string,
+  player: PlayerModel
+) => {
+  if (playersDisconnected.has(playerId)) {
+    const existingTimeout = playersDisconnected.get(playerId)
+    if (existingTimeout) {
+      clearTimeout(existingTimeout)
+    }
+    playersDisconnected.delete(playerId)
+  }
+
+  addPlayer(socket.id, playerId)
+  socket.join(gameId)
+  updatePlayerStatus(playerId, true, socket.id)
+  room.readyPlayers.add(playerId)
+
+  const gameHistory = getGameHistory(gameId)
+  syncGameState(room, gameHistory)
+
+  if (gameHistory && room.gameInfo.currentDay !== gameHistory.currentRound) {
+    const safeRound = Math.min(
+      Math.max(room.gameInfo.currentDay, gameHistory.currentRound),
+      room.totalRounds
+    )
+    room.gameInfo.currentDay = safeRound
+
+    if (gameHistory) {
+      gameHistory.currentRound = safeRound
+    }
+  }
+
+  const completeGameSnapshot = createCompleteGameSnapshot(room, gameId, gameHistory)
+  socket.emit('sync_complete', completeGameSnapshot)
+
+  sendStateSpecificUpdates(io, socket, room, gameId, gameHistory)
+
+  socket.to(gameId).emit('player_reconnected', {
+    playerId,
+    nickname: player.nickname,
+  })
+}
+
+const syncGameState = (
+  room: GameModel & { readyPlayers: Set<string> },
+  gameHistory: GameHistoryModel
+) => {
+  if (!gameHistory) return
+
+  const actualCurrentRound = gameHistory.currentRound || room.gameInfo.currentDay
+  const maxValidRound = Math.min(actualCurrentRound, room.totalRounds)
+  const safeCurrentRound = Math.max(1, maxValidRound)
+
+  if (room.gameInfo.currentDay !== safeCurrentRound) {
+    const expectedNextRound = room.gameInfo.currentDay + 1
+    if (safeCurrentRound > expectedNextRound && safeCurrentRound - expectedNextRound > 1) {
+      room.gameInfo.currentDay = Math.min(expectedNextRound, room.totalRounds)
+    } else {
+      room.gameInfo.currentDay = safeCurrentRound
+    }
+
+    const currentRoundData = gameHistory.rounds.find(
+      (round: RoundRecordModel) => round.roundNumber === room.gameInfo.currentDay
+    )
+
+    if (currentRoundData) {
+      room.gameInfo.currentFishPrice = currentRoundData.fishPrice
+      room.gameInfo.nextRoundHint = currentRoundData.hint
+    }
+  }
+}
+
+const sendStateSpecificUpdates = (
+  io: SocketIOServer,
+  socket: Socket,
+  room: GameModel & { readyPlayers: Set<string> },
+  gameId: string,
+  gameHistory: GameHistoryModel
+) => {
+  const actualCurrentRound = gameHistory?.currentRound || room.gameInfo.currentDay
+
+  if (room.state === 'waiting') {
+    io.to(gameId).emit('update_players', room.players)
+  } else if (room.state === 'in_progress') {
+    socket.emit('complete_round_sync', {
+      currentRound: actualCurrentRound,
+      fishPrice: room.gameInfo.currentFishPrice,
+      hint: room.gameInfo.nextRoundHint,
+      lastRoundResult: room.gameInfo.lastRoundHintResult,
+      roundHistory: gameHistory?.rounds || [],
+      totalRounds: room.totalRounds,
+      gameState: room.state,
+    })
+
+    const timerState = gameTimersState.get(gameId)
+    if (timerState?.isRunning) {
+      const remainingTime = Math.max(0, timerState.duration - (Date.now() - timerState.startTime))
+      socket.emit('timer_started', {
+        startTime: timerState.startTime,
+        duration: timerState.duration,
+        remainingTime,
+      })
+    }
+  }
+}
+
+const createCompleteGameSnapshot = (
+  room: GameModel & { readyPlayers: Set<string> },
+  gameId: string,
+  gameHistory: GameHistoryModel
+) => {
+  const timerState = gameTimersState.get(gameId)
+  const actualCurrentRound = gameHistory?.currentRound || room.gameInfo.currentDay
+
+  return {
+    gameId: room.gameId,
+    gameState: room.state,
+    players: room.players.map((player) => ({
+      ...player,
+      isOnline: getPlayerStatus(player.id),
+    })),
+    gameInfo: {
+      ...room.gameInfo,
+      currentDay: actualCurrentRound,
+    },
+    totalRounds: room.totalRounds,
+    currentRound: actualCurrentRound,
+    fishPrice: room.gameInfo.currentFishPrice,
+    readyPlayersCount: room.readyPlayers.size,
+    roundHistory: gameHistory?.rounds || [],
+    timerState: timerState
+      ? {
+          startTime: timerState.startTime,
+          duration: timerState.duration,
+          isRunning: timerState.isRunning,
+          remainingTime: timerState.isRunning
+            ? Math.max(0, timerState.duration - (Date.now() - timerState.startTime))
+            : 0,
+        }
+      : null,
+    timestamp: Date.now(),
+    debugInfo: {
+      serverTime: new Date().toISOString(),
+      gameStartTime: room.gameStartTime || null,
+    },
+  }
+}
+
+// ========================= 유틸리티 함수들 =========================
+
+export const getReconnectionStatus = (playerId: string) => {
+  return {
+    isReconnecting: playersReconnecting.has(playerId),
+    lastReconnectTime: playersReconnecting.get(playerId),
+  }
+}
+
+export const validateGameState = (gameId: string) => {
+  const room = getRoom(gameId)
+  if (!room) return null
+
+  const gameHistory = getGameHistory(gameId)
+  const onlinePlayers = room.players.filter((player) => getPlayerStatus(player.id))
+
+  return {
+    gameId,
+    state: room.state,
+    totalPlayers: room.players.length,
+    onlinePlayers: onlinePlayers.length,
+    readyPlayers: room.readyPlayers.size,
+    currentRound: room.gameInfo.currentDay,
+    historyRound: gameHistory?.currentRound,
+    isStateSynced: !gameHistory || room.gameInfo.currentDay === gameHistory.currentRound,
+  }
+}
+
+export const forceSync = (io: SocketIOServer, gameId: string, playerId: string) => {
+  const room = getRoom(gameId)
+  if (!room) return false
+
+  const player = room.players.find((p) => p.id === playerId)
+  if (!player) return false
+
+  const socketId = Array.from(playersMap.entries()).find(([_, id]) => id === playerId)?.[0]
+  if (!socketId) return false
+
+  const socket = io.sockets.sockets.get(socketId)
+  if (!socket) return false
+
+  const gameHistory = getGameHistory(gameId)
+  const completeGameSnapshot = createCompleteGameSnapshot(room, gameId, gameHistory)
+
+  socket.emit('sync_complete', completeGameSnapshot)
+  return true
+}
+
+export const validateRoundBeforeTimerStart = (gameId: string, expectedRound: number) => {
+  const history = getGameHistory(gameId)
+
+  if (!history) {
+    return expectedRound
+  }
+
+  const { currentRound } = history
+
+  if (expectedRound > currentRound + 1) {
+    return currentRound + 1
+  }
+
+  return expectedRound
 }

--- a/server/game/history.ts
+++ b/server/game/history.ts
@@ -1,0 +1,77 @@
+import { GameHistoryModel, RoundRecordModel } from '../../types/game.js'
+
+import { gameHistory } from './store.js'
+
+export const getGameHistory = (gameId: string): GameHistoryModel | undefined => {
+  return gameHistory.get(gameId)
+}
+
+export const updateRoundHistory = (
+  gameId: string,
+  roundNumber: number,
+  fishPrice: number,
+  hint: string,
+  hintResult: string = ''
+) => {
+  let history = gameHistory.get(gameId)
+
+  if (!history) {
+    history = {
+      rounds: [],
+      currentRound: 1,
+    }
+    gameHistory.set(gameId, history)
+  }
+
+  if (roundNumber <= 0) {
+    return history
+  }
+
+  const lastRound = Math.max(...history.rounds.map((r) => r.roundNumber), 0)
+  if (roundNumber > lastRound + 1) {
+    for (let i = lastRound + 1; i < roundNumber; i++) {
+      const missingRoundData: RoundRecordModel = {
+        roundNumber: i,
+        fishPrice: 0,
+        hint: '',
+        hintResult: '',
+        timestamp: Date.now(),
+      }
+
+      const existingIndex = history.rounds.findIndex((r) => r.roundNumber === i)
+      if (existingIndex === -1) {
+        history.rounds.push(missingRoundData)
+      }
+    }
+  }
+
+  const existingRoundIndex = history.rounds.findIndex((r) => r.roundNumber === roundNumber)
+  const roundData: RoundRecordModel = {
+    roundNumber,
+    fishPrice,
+    hint,
+    hintResult,
+    timestamp: Date.now(),
+  }
+
+  if (existingRoundIndex >= 0) {
+    history.rounds[existingRoundIndex] = roundData
+  } else {
+    history.rounds.push(roundData)
+  }
+
+  const newCurrentRound = Math.max(history.currentRound, roundNumber)
+  if (newCurrentRound - history.currentRound > 1) {
+    history.currentRound = history.currentRound + 1
+  } else {
+    history.currentRound = newCurrentRound
+  }
+
+  history.rounds.sort((a, b) => a.roundNumber - b.roundNumber)
+
+  return history
+}
+
+export const cleanupGameHistory = (gameId: string) => {
+  gameHistory.delete(gameId)
+}

--- a/server/game/player.ts
+++ b/server/game/player.ts
@@ -1,9 +1,19 @@
 import { Socket } from 'socket.io'
 
-import { gameRooms, getRoom, removePlayer, removeRoom } from './store.js'
-import { clearGameTimers } from './timer.js'
+import { PlayerIdType, SocketIdType } from '../../types/game'
 
-export const removePlayerFromRoom = (socket: Socket, playerId: string, gameId: string) => {
+import { getRoom, removeRoom } from './room.js'
+import { gameRooms, playersStatus, playersMap } from './store.js'
+import { clearAllGameTimers } from './timer.js'
+
+export const addPlayer = (socketId: SocketIdType, playerId: PlayerIdType) =>
+  playersMap.set(socketId, playerId)
+
+export const removePlayer = (socketId: SocketIdType) => playersMap.delete(socketId)
+
+export const getPlayer = (socketId: SocketIdType) => playersMap.get(socketId)
+
+const removePlayerFromRoom = (socket: Socket, playerId: string, gameId: string) => {
   const room = getRoom(gameId)
   if (!room) {
     return false
@@ -19,7 +29,7 @@ export const removePlayerFromRoom = (socket: Socket, playerId: string, gameId: s
   socket.to(gameId).emit('update_players', room.players)
 
   if (room.players.length === 0) {
-    clearGameTimers(gameId)
+    clearAllGameTimers(gameId)
     removeRoom(gameId)
   }
 
@@ -41,4 +51,31 @@ export const handlePlayerLeave = (socket: Socket, playerId: string, leaveGameId?
     }
   })
   removePlayer(socket.id)
+}
+
+export const updatePlayerStatus = (
+  playerId: PlayerIdType,
+  isOnline: boolean,
+  socketId?: SocketIdType
+) => {
+  playersStatus.set(playerId, {
+    isOnline,
+    lastSeen: Date.now(),
+    socketId: isOnline ? socketId : undefined,
+  })
+}
+
+export const getPlayerStatus = (playerId: PlayerIdType): boolean => {
+  return playersStatus.get(playerId)?.isOnline ?? false
+}
+
+export const clearPlayerStatus = (playerId: PlayerIdType) => {
+  playersStatus.delete(playerId)
+}
+
+export const getOnlinePlayers = (gameId: string): PlayerIdType[] => {
+  const room = gameRooms.get(gameId)
+  if (!room) return []
+
+  return room.players.filter((player) => getPlayerStatus(player.id)).map((player) => player.id)
 }

--- a/server/game/room.ts
+++ b/server/game/room.ts
@@ -1,0 +1,8 @@
+import { GameModel } from '../../types/game'
+
+import { gameRooms } from './store.js'
+
+export const getRoom = (gameId: string) => gameRooms.get(gameId)
+export const addRoom = (gameId: string, game: GameModel & { readyPlayers: Set<string> }) =>
+  gameRooms.set(gameId, game)
+export const removeRoom = (gameId: string) => gameRooms.delete(gameId)

--- a/server/game/store.ts
+++ b/server/game/store.ts
@@ -1,16 +1,40 @@
-import { GameModel, PlayerIdType, SocketIdType } from '@/types/game.js'
+import { GameHistoryModel, GameModel, PlayerIdType, SocketIdType } from '../../types/game.js'
 
 export const gameRooms = new Map<string, GameModel & { readyPlayers: Set<string> }>()
+export const gameHistory = new Map<string, GameHistoryModel>()
+
 export const playersMap = new Map<SocketIdType, PlayerIdType>()
+export const playersStatus = new Map<
+  PlayerIdType,
+  {
+    isOnline: boolean
+    lastSeen: number
+    socketId?: SocketIdType
+  }
+>()
+
+export const playersReconnecting = new Map<PlayerIdType, number>()
+export const playersDisconnected = new Map<PlayerIdType, NodeJS.Timeout>()
+export const playersReconnectingSet = new Set<string>()
+
 export const gameTimers = new Map<string, NodeJS.Timeout>()
 export const roundTimers = new Map<string, NodeJS.Timeout>()
+export const gameTimersState = new Map<
+  string,
+  {
+    startTime: number
+    duration: number
+    isRunning: boolean
+  }
+>()
 
-export const getRoom = (gameId: string) => gameRooms.get(gameId)
-export const addRoom = (gameId: string, game: GameModel & { readyPlayers: Set<string> }) =>
-  gameRooms.set(gameId, game)
-export const removeRoom = (gameId: string) => gameRooms.delete(gameId)
-
-export const addPlayer = (socketId: SocketIdType, playerId: PlayerIdType) =>
-  playersMap.set(socketId, playerId)
-export const removePlayer = (socketId: SocketIdType) => playersMap.delete(socketId)
-export const getPlayerId = (socketId: SocketIdType) => playersMap.get(socketId)
+export const roundProgress = new Map<
+  string,
+  {
+    gameId: string
+    currentRound: number
+    isTransitioning: boolean
+    lastUpdateTime: number
+    lastValidatedRound: number
+  }
+>()

--- a/server/game/timer.ts
+++ b/server/game/timer.ts
@@ -4,9 +4,11 @@ import { gameConfig, PRICE_THRESHOLD } from '../../constants/game.js'
 import { generateNewFishPrice, isPriceChangeHigh, shouldHintMatch } from '../../lib/utils/game.js'
 import { GameModel } from '../../types/game.js'
 
-import { gameTimers, getRoom, roundTimers } from './store.js'
+import { updateRoundHistory, cleanupGameHistory } from './history.js'
+import { getRoom } from './room.js'
+import { gameTimers, roundTimers, gameTimersState } from './store.js'
 
-export const startGameTimer = (
+export const startRoundTimer = (
   io: SocketIOServer,
   gameId: string,
   room: GameModel & { readyPlayers: Set<string> }
@@ -27,12 +29,28 @@ export const startGameTimer = (
     roundTimers.delete(gameId)
   }
 
+  const startTime = Date.now()
+  const duration = gameConfig.INITIAL_TIMER * 1000
+
+  gameTimersState.set(gameId, {
+    startTime,
+    duration,
+    isRunning: true,
+  })
+
+  io.to(gameId).emit('timer_started', {
+    startTime,
+    duration,
+    currentRound: room.gameInfo.currentDay,
+  })
+
   let timer = gameConfig.INITIAL_TIMER
   const intervalId = setInterval(() => {
     const currentRoom = getRoom(gameId)
     if (!currentRoom || currentRoom.state !== 'in_progress') {
       clearInterval(intervalId)
       roundTimers.delete(gameId)
+      gameTimersState.delete(gameId)
       return
     }
 
@@ -40,16 +58,21 @@ export const startGameTimer = (
     io.to(gameId).emit('timer_update', timer)
 
     if (timer === 0) {
-      handleTimerEnd(io, gameId, currentRoom)
+      processRoundEnd(io, gameId, currentRoom)
       clearInterval(intervalId)
       roundTimers.delete(gameId)
+
+      const timerState = gameTimersState.get(gameId)
+      if (timerState) {
+        timerState.isRunning = false
+      }
     }
   }, 1000)
 
   roundTimers.set(gameId, intervalId)
 }
 
-const handleTimerEnd = (
+const processRoundEnd = (
   io: SocketIOServer,
   gameId: string,
   currentRoom: GameModel & { readyPlayers: Set<string> }
@@ -57,38 +80,13 @@ const handleTimerEnd = (
   const isLastRound = currentRoom.gameInfo.currentDay === currentRoom.totalRounds
 
   if (isLastRound) {
-    handleLastRound(io, gameId, currentRoom)
+    processGameEnd(io, gameId, currentRoom)
   } else {
-    handleNextRound(io, gameId, currentRoom)
+    processNextRound(io, gameId, currentRoom)
   }
 }
 
-const handleLastRound = (
-  io: SocketIOServer,
-  gameId: string,
-  currentRoom: GameModel & { readyPlayers: Set<string> }
-) => {
-  try {
-    const prevHint = currentRoom.hints[currentRoom.gameInfo.currentDay - 2]
-    if (!prevHint) return
-
-    const isHintMatched = shouldHintMatch()
-    const priceChangeDirection = isHintMatched
-      ? prevHint.expectedChange
-      : prevHint.expectedChange === 'up'
-        ? 'down'
-        : 'up'
-
-    const oldPrice = currentRoom.gameInfo.currentFishPrice
-    const newPrice = generateNewFishPrice(oldPrice, priceChangeDirection)
-
-    io.to(gameId).emit('last_fish_price', newPrice)
-  } catch (error) {
-    console.error('마지막 라운드의 생선 가격을 계산하는데 실패하였습니다.', error)
-  }
-}
-
-const handleNextRound = (
+const processNextRound = (
   io: SocketIOServer,
   gameId: string,
   currentRoom: GameModel & { readyPlayers: Set<string> }
@@ -106,15 +104,26 @@ const handleNextRound = (
       currentRoom.gameInfo.currentDay = currentRoom.totalRounds
     }
 
-    updateGameInfo(io, gameId, currentRoom)
-    startGameTimer(io, gameId, currentRoom)
+    calculateAndUpdateGameInfo(io, gameId, currentRoom)
+
+    updateRoundHistory(
+      gameId,
+      currentRoom.gameInfo.currentDay,
+      currentRoom.gameInfo.currentFishPrice,
+      currentRoom.gameInfo.nextRoundHint,
+      currentRoom.gameInfo.lastRoundHintResult
+    )
+
+    currentRoom.readyPlayers.clear()
+
+    startRoundTimer(io, gameId, currentRoom)
   } catch (error) {
     console.error('다음 라운드로 게임을 업데이트하는데 실패하였습니다.', error)
     io.to(gameId).emit('update_game_info', currentRoom.gameInfo)
   }
 }
 
-const updateGameInfo = (
+const calculateAndUpdateGameInfo = (
   io: SocketIOServer,
   gameId: string,
   currentRoom: GameModel & { readyPlayers: Set<string> }
@@ -156,10 +165,76 @@ const updateGameInfo = (
     nextRoundHint: currentHint?.hint || '',
   }
 
-  io.to(gameId).emit('update_game_info', currentRoom.gameInfo)
+  console.log(`📊 게임 정보 업데이트:`, {
+    gameId,
+    round: currentRoom.gameInfo.currentDay,
+    priceChange: `${oldPrice} → ${newPrice}`,
+    priceChangeDirection,
+    isHintMatched,
+    hint: currentHint?.hint?.substring(0, 20) + '...' || 'No hint',
+  })
+
+  io.to(gameId).emit('update_game_info', {
+    ...currentRoom.gameInfo,
+    debugInfo: {
+      oldPrice,
+      newPrice,
+      priceChangeDirection,
+      isHintMatched,
+      roundTransition: {
+        from: currentRoom.gameInfo.currentDay - 1,
+        to: currentRoom.gameInfo.currentDay,
+      },
+    },
+  })
+
+  io.to(gameId).emit('round_sync', {
+    currentRound: currentRoom.gameInfo.currentDay,
+    fishPrice: newPrice,
+    hint: currentRoom.gameInfo.nextRoundHint,
+    lastRoundResult: outcomeMessage,
+    timestamp: Date.now(),
+  })
 }
 
-export const clearGameTimers = (gameId: string) => {
+const processGameEnd = (
+  io: SocketIOServer,
+  gameId: string,
+  currentRoom: GameModel & { readyPlayers: Set<string> }
+) => {
+  try {
+    const prevHint = currentRoom.hints[currentRoom.gameInfo.currentDay - 2]
+    if (!prevHint) return
+
+    const isHintMatched = shouldHintMatch()
+    const priceChangeDirection = isHintMatched
+      ? prevHint.expectedChange
+      : prevHint.expectedChange === 'up'
+        ? 'down'
+        : 'up'
+
+    const oldPrice = currentRoom.gameInfo.currentFishPrice
+    const newPrice = generateNewFishPrice(oldPrice, priceChangeDirection)
+
+    updateRoundHistory(
+      gameId,
+      currentRoom.gameInfo.currentDay,
+      newPrice,
+      '게임 종료',
+      '마지막 라운드 완료'
+    )
+
+    io.to(gameId).emit('last_fish_price', newPrice)
+
+    setTimeout(() => {
+      cleanupGameHistory(gameId)
+    }, 5000)
+  } catch (error) {
+    console.error('마지막 라운드의 생선 가격을 계산하는데 실패하였습니다.', error)
+  }
+}
+
+export const clearAllGameTimers = (gameId: string) => {
   const gameTimer = gameTimers.get(gameId)
   if (gameTimer) {
     clearTimeout(gameTimer)
@@ -171,4 +246,6 @@ export const clearGameTimers = (gameId: string) => {
     clearInterval(roundTimer)
     roundTimers.delete(gameId)
   }
+
+  gameTimersState.delete(gameId)
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import {
   handlePlayerReady,
   handleRequestFirstRoundHint,
   handleRequestPlayerInfo,
+  handleRequestSync,
   handleSendMessage,
   handleSendNotice,
   handleStartGame,
@@ -52,6 +53,8 @@ app.prepare().then(() => {
 
     socket.on('leave_game', (data) => handleLeaveGame(socket, data))
     socket.on('disconnect', () => handleDisconnect(socket))
+
+    socket.on('request_sync', (data) => handleRequestSync(io, socket, data))
   })
 
   httpServer

--- a/server/socket/config.ts
+++ b/server/socket/config.ts
@@ -9,6 +9,8 @@ export const createSocketServer = (httpServer: HttpServer) => {
       origin: ['https://admin.socket.io'],
       credentials: true,
     },
+    pingInterval: 5000,
+    pingTimeout: 3000,
   })
   instrument(io, {
     auth: false,

--- a/store/game.ts
+++ b/store/game.ts
@@ -1,6 +1,34 @@
 import { create } from 'zustand'
 
-import { GameResultModel } from '@/types/game'
+import { GameResultModel, GameStateModel } from '@/types/game'
+
+interface GameSessionModel {
+  fishPrice: number
+  prevFishPrice: number
+  currentRound: number
+  totalRounds: number
+  hint: string
+  hintResult: string
+  lastUpdated: number
+}
+
+export interface GameSyncPayloadModel {
+  currentDay?: number
+  currentRound?: number
+  currentFishPrice?: number
+  fishPrice?: number
+  nextRoundHint?: string
+  hint?: string
+  lastRoundHintResult?: string
+  lastRoundResult?: string
+  hintResult?: string
+  totalRounds?: number
+  gameState?: GameStateModel
+  timestamp?: number
+  forceUpdate?: boolean
+  forceHintUpdate?: boolean
+  syncVersion?: string
+}
 
 interface GameStoreModel {
   gameId: string | null
@@ -8,26 +36,109 @@ interface GameStoreModel {
   rounds: number
   isLeader: boolean
   results: GameResultModel[] | null
-  setGameId: (id: string) => void
-  setPlayerId: (playerId: string) => void
+  hintState: GameSessionModel
+  setGameId: (id: string | null) => void
+  setPlayerId: (id: string | null) => void
   setGameRounds: (rounds: number) => void
   setIsLeader: (isLeader: boolean) => void
   setResults: (results: GameResultModel[]) => void
   resetResults: () => void
+  updateHintState: (update: Partial<GameSessionModel>) => void
+  setFishPrice: (price: number, prevPrice?: number) => void
+  setCurrentRound: (round: number) => void
+  setHint: (hint: string) => void
+  setHintResult: (result: string) => void
+  resetGameState: () => void
+  syncGameInfo: (gameInfo: GameSyncPayloadModel) => void
 }
 
-const useGameStore = create<GameStoreModel>((set) => ({
+const createInitialHintState = (): GameSessionModel => ({
+  fishPrice: 100,
+  prevFishPrice: 100,
+  currentRound: 1,
+  totalRounds: 10,
+  hint: '',
+  hintResult: '',
+  lastUpdated: Date.now(),
+})
+
+const getInitialState = () => ({
   gameId: null,
   playerId: null,
   rounds: 10,
   isLeader: false,
   results: null,
-  setGameId: (id) => set({ gameId: id }),
-  setPlayerId: (id) => set({ playerId: id }),
+  hintState: createInitialHintState(),
+})
+
+const useGameStore = create<GameStoreModel>((set, get) => ({
+  ...getInitialState(),
+  setGameId: (id) => {
+    set({ gameId: id })
+  },
+  setPlayerId: (id) => {
+    set({ playerId: id })
+  },
   setGameRounds: (rounds) => set({ rounds }),
   setIsLeader: (isLeader) => set({ isLeader }),
   setResults: (results) => set({ results }),
   resetResults: () => set({ results: null }),
+  updateHintState: (update) => {
+    if (Object.keys(update).length === 0) return
+    set((state) => ({
+      hintState: {
+        ...state.hintState,
+        ...update,
+        lastUpdated: Date.now(),
+      },
+    }))
+  },
+  setFishPrice: (price, prevPrice) => {
+    const currentState = get().hintState
+    get().updateHintState({
+      fishPrice: price,
+      prevFishPrice: prevPrice ?? currentState.fishPrice,
+    })
+  },
+  setCurrentRound: (round) => {
+    get().updateHintState({ currentRound: round })
+  },
+  setHint: (hint) => {
+    get().updateHintState({ hint })
+  },
+  setHintResult: (result) => {
+    get().updateHintState({ hintResult: result })
+  },
+  syncGameInfo: (gameInfo) => {
+    const currentState = get().hintState
+    const updates: Partial<GameSessionModel> = {}
+
+    const currentRound = gameInfo.currentRound ?? gameInfo.currentDay
+    const fishPrice = gameInfo.fishPrice ?? gameInfo.currentFishPrice
+    const hint = gameInfo.hint ?? gameInfo.nextRoundHint
+    const hintResult = gameInfo.hintResult ?? gameInfo.lastRoundHintResult
+
+    if (currentRound !== undefined) updates.currentRound = currentRound
+    if (fishPrice !== undefined) {
+      updates.prevFishPrice = currentState.fishPrice
+      updates.fishPrice = fishPrice
+    }
+    if (hint !== undefined) updates.hint = hint
+    if (hintResult !== undefined) updates.hintResult = hintResult
+    if (gameInfo.totalRounds !== undefined) updates.totalRounds = gameInfo.totalRounds
+
+    get().updateHintState(updates)
+  },
+  resetGameState: () => {
+    set({
+      gameId: null,
+      playerId: null,
+      rounds: 10,
+      isLeader: false,
+      results: null,
+      hintState: createInitialHintState(),
+    })
+  },
 }))
 
 export default useGameStore

--- a/types/debug.ts
+++ b/types/debug.ts
@@ -1,0 +1,11 @@
+export interface SimpleDebugSocketModel {
+  status: () => void
+  reconnect: () => void
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Window {
+    debugSocket?: SimpleDebugSocketModel
+  }
+}

--- a/types/game.ts
+++ b/types/game.ts
@@ -1,13 +1,18 @@
-export interface AvatarModel {
-  imageUrl: string
-  nickName: string
-  isLeader?: boolean
+export interface PlayerModel {
   id: string
+  nickname: string
+  character: string
+  score?: number
+  isInWaitingRoom: boolean
 }
 
-export interface TransactionResultModel {
-  playerId: string
-  message: string
+export interface AvatarModel extends Pick<PlayerModel, 'id' | 'nickname'> {
+  imageUrl: string
+  isLeader?: boolean
+}
+
+export interface GameResultModel extends Pick<PlayerModel, 'id' | 'nickname' | 'character'> {
+  score: number
 }
 
 export interface GameStateModel {
@@ -19,32 +24,9 @@ export interface GameStateModel {
   isModalOpen: boolean
 }
 
-export interface GameModel {
-  gameId: string
-  totalRounds: number
-  state: 'waiting' | 'in_progress' | 'ended'
-  hints: HintModel[]
-  gameInfo: {
-    currentDay: number
-    currentFishPrice: number
-    lastRoundHintResult: string
-    nextRoundHint: string
-  }
-  players: PlayerModel[]
-  gameResults: GameResultModel[]
-}
-
-export interface PlayerModel {
-  id: string
-  nickname: string
-  character: string
-  score?: number
-  isInWaitingRoom: boolean
-}
-
-export interface HintContentModel {
-  nextRoundHint: string
-  lastRoundHintResult: string
+export interface TransactionResultModel {
+  playerId: string
+  message: string
 }
 
 export interface HintModel {
@@ -57,11 +39,50 @@ export interface HintModel {
   mismatchOutcomeLow: string
 }
 
-export interface GameResultModel {
-  id: string
-  nickname: string
-  score: number
-  character: string
+export interface HintContentModel {
+  nextRoundHint: string
+  lastRoundHintResult: string
+}
+
+export interface RoundRecordModel {
+  roundNumber: number
+  fishPrice: number
+  hint: string
+  hintResult: string
+  timestamp: number
+}
+
+export interface GameHistoryModel {
+  rounds: RoundRecordModel[]
+  currentRound: number
+}
+
+export interface GameInfoModel {
+  currentDay: number
+  currentFishPrice: number
+  lastRoundHintResult: string
+  nextRoundHint: string
+}
+
+export interface GameModel {
+  gameId: string
+  totalRounds: number
+  state: 'waiting' | 'in_progress' | 'ended'
+  hints: HintModel[]
+  gameInfo: GameInfoModel
+  players: PlayerModel[]
+  gameResults: GameResultModel[]
+  gameStartTime?: number
+}
+
+export interface GameSnapshotModel {
+  gameId: string
+  players: PlayerModel[]
+  gameInfo: GameInfoModel
+  gameState: GameStateModel
+  gameHistory: GameHistoryModel
+  gameResults: GameResultModel[]
+  currentPlayerId: string
 }
 
 export type SocketIdType = string


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
실시간 멀티플레이어 게임에서 네트워크가 끊어져도 게임을 계속할 수 있도록 재연결 기능을 만들었습니다.

### 1. 해결한 문제들

#### 1-1. 게임 상태 동기화 이슈
- 재연결 후 타이머가 초기화되던 문제 → 정확한 남은 시간으로 복원
- 힌트랑 이전 라운드 결과가 사라지던 문제 → 모든 게임 히스토리 보존
- 플레이어 코인/물고기 개수 틀어지던 문제 → 정확한 자산 상태 유지
- 다른 플레이어들 상태 안 보이던 문제 → 실시간 온라인 상태 반영

#### 1-2. 재연결 범위 확장
- 게임 중에만 재연결 되던 것을 대기방까지 확장
- 플레이어 목록 동기화 문제도 해결

#### 1-3. 플레이어 관리 개선
- 재연결한 걸 다른 플레이어들이 몰라서 생기던 문제들 해결
- 60초 유예 기간 추가해서 일시적 연결 끊김은 허용

#### 1-4. useSocketNavigation 훅 문제 해결
- **문제**: 기존 코드에서 `socket.removeAllListeners()` 호출로 인해 재연결 후 게임 시작 시 게임 페이지로 이동하지 않는 문제
- **원인**: 모든 소켓 이벤트 리스너가 제거되어서 `game_started`, `sync_complete` 등 핵심 이벤트 수신 불가
- **해결**: `removeAllListeners()` 제거하고 기존 개별 이벤트 해제 방식 유지

### 2. 주요 기능

#### 2-1. 서버 측 (Backend)
- 게임 히스토리 시스템 완전히 새로 구현 (history.js)
- 방 관리 로직 분리해서 정리 (room.js)  
- 플레이어 상태 추적 로직 전면 개선
- 타이머 상태 관리 기능 추가
- 재연결 핸들러 구현

#### 2-2. 클라이언트 측 (Frontend)
- 자동 재연결 로직 구현
- 게임 데이터 보존 및 복원 로직
- 재연결 상태 피드백 (토스트 알림)
- 에러 처리 및 안내

### 3. 동작 과정
1. 연결 끊어짐 감지 → 자동 재연결 시도 + 서버에서 60초 대기
2. 재연결 성공 → 클라이언트가 동기화 요청
3. 서버가 전체 게임 스냅샷 전송 → 클라이언트 상태 복원


## 📁 수정한 파일들

### 1. 서버
- `game/history.js` : 신규 - 게임 진행 기록 관리
- `game/room.js` : 신규 - 방 관리 기능 분리
- `game/player.js` : 대폭 수정 - 상태 추적 로직 개선
- `game/timer.js` : 기능 추가 - 상태 관리 
- `game/handlers.js` : 재연결 로직 추가
- `server.js`  : 동기화 이벤트 핸들러 추가

### 2. 클라이언트  
- `contexts/socket-provider.tsx` : 재연결 로직 구현
- `app/user-info/page.tsx` : 데이터 구조 변경 대응
- `app/game/[gameId]/page.tsx` : 동기화 핸들러 추가

## 🔧 변경 사항
- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/b26905ea-2b8f-49b0-a209-64b9defc7a56

https://github.com/user-attachments/assets/ba031481-7928-489d-bd22-6e16c51fde5b

- **재연결 토스트 알림 과다 출력 해서 개발 모드에서만 표시되도록 조건부 처리했습니다.**
- **PC영상은 길어서 줄였습니다.**



## 📄 기타

### 1. 테스트 완료 
- 게임 중 네트워크 단절 후 재연결 → 정상 복원 
- 대기방 재연결 → 플레이어 목록 정상 동기화 
- 다중 플레이어 재연결 → 충돌 없이 처리 
- 60초 후 자동 제거 → 정상 동작 
- 타이머 → 복원 ✓

### 2. 남은 작업
- 전체 앱에서 재연결 테스트 (다른 화면들도)
- 연결 상태 UI 개선 (별도 이슈로 진행 예정)

### 3. 왜 어려웠는지
1. 클라이언트-서버 양쪽에서 타이머, 플레이어 상태, 게임 진행도 등 모든 걸 맞춰야 했음
2. 혼자 할 때는 되는데 둘이서 하면 안 되거나, 같은 상황인데 어떨 때는 되고 어떨 때는 안 됨
3. 게임 끝나는 순간에 재연결하면 타이머 멈추거나 거래가 안되는 경우들
4. 재연결 후 힌트가 바로 반영 안 되어서 디버깅하기 힘들었음

### 3. 개발하면서 든 생각
- 로컬스토리지나 세션스토리지에 게임 상태를 관리해서 만드는 게 나았을까? 싶은 생각이 듦
- 순전히 서버 상태에만 의존하다 보니 디버깅이나 상태 추적이 더 어려웠던 것 같음

## Sourcery 요약

네트워크 중단 시 게임 진행 상황과 로비 상태를 유지하기 위한 강력한 재연결 및 상태 동기화 시스템을 추가합니다.

새로운 기능:
- 60초의 유예 기간을 두고 게임 및 로비 단계 모두에서 자동 재연결을 구현합니다.
- 완전한 상태 복원을 위해 서버 측 게임 기록 및 스냅샷 메커니즘을 도입합니다.
- 토스트 및 수동 디버그 컨트롤을 사용하여 클라이언트 측 자동 재연결 및 동기화 로직을 추가합니다.

버그 수정:
- 재연결 후 정확한 타이머, 힌트, 라운드 결과 및 플레이어 자산을 보존합니다.
- 다른 플레이어의 상태를 복원하고 페이지 탐색을 차단하는 손실된 이벤트 리스너 문제를 해결합니다.

개선 사항:
- 서버 로직을 전용 룸/기록 모듈로 리팩터링하고 타이머 및 플레이어 상태 추적을 중앙 집중화합니다.
- 동기화된 게임 정보를 위해 클라이언트 스토어 모델을 개선하고 소켓 이벤트 처리를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add robust reconnection and state-synchronization system to maintain game progress and lobby state across network disruptions

New Features:
- Implement automated reconnection across both game and lobby phases with a 60-second grace period
- Introduce server-side game history and snapshot mechanism for full state restoration
- Add client-side auto-reconnect and sync logic with toasts and manual debug controls

Bug Fixes:
- Preserve accurate timer, hints, round results, and player assets after reconnect
- Restore other players’ statuses and resolve lost event listener issues that blocked page navigation

Enhancements:
- Refactor server logic into dedicated room/history modules and centralize timer and player-status tracking
- Enhance client-store model for synchronized game info and improve socket event handling

</details>