### PR TITLE
[feat] 페이지 이탈 방지 개선 및 소켓 로직 리팩토링

### DIFF
--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -66,14 +66,13 @@ const GamePage = ({ params }) => {
   const { showToast } = useToastStore()
   const { socket } = useSocket()
   const { isOnline, isNetworkOffline } = useNetworkStatus()
-  const { gameData, saveGameData, getGameData } = useGameState()
+  const { gameData, getGameData } = useGameState()
   const { startHeartbeat, stopHeartbeat, isHeartbeatActive, getLastHeartbeatTime } = useHeartbeat()
 
   useSocketNavigation(gameId)
 
   useEffect(() => {
-    const gameId = gameData.gameId
-    const playerId = gameData.playerId
+    const { gameId, playerId } = gameData
     const isSocketConnected = socket && socket.connected
 
     const hasValidGameData = gameId && playerId

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -72,16 +72,24 @@ const GamePage = ({ params }) => {
   useSocketNavigation(gameId)
 
   useEffect(() => {
-    if (gameData.gameId && gameData.playerId && socket?.connected) {
+    const gameId = gameData.gameId
+    const playerId = gameData.playerId
+    const isSocketConnected = socket && socket.connected
+
+    const hasValidGameData = gameId && playerId
+    const canStartHeartbeat = hasValidGameData && isSocketConnected
+
+    if (canStartHeartbeat) {
       console.log('💓 게임 하트비트 시작:', {
-        gameId: gameData.gameId,
-        playerId: gameData.playerId,
+        gameId,
+        playerId,
       })
+
       startHeartbeat(socket, getGameData, () => {
         console.log('💔 하트비트 실패 - 동기화 요청')
         socket.emit('request_sync', {
-          gameId: gameData.gameId,
-          playerId: gameData.playerId,
+          gameId,
+          playerId,
         })
       })
     }
@@ -90,14 +98,7 @@ const GamePage = ({ params }) => {
       console.log('💓 게임 하트비트 정지')
       stopHeartbeat()
     }
-  }, [
-    gameData.gameId,
-    gameData.playerId,
-    socket?.connected,
-    startHeartbeat,
-    stopHeartbeat,
-    getGameData,
-  ])
+  }, [gameData.gameId, gameData.playerId, socket, startHeartbeat, stopHeartbeat, getGameData])
 
   useEffect(() => {
     socket.on('player_info', handlePlayerInitialize)
@@ -386,6 +387,8 @@ const GamePage = ({ params }) => {
   }
 
   const totalCoin = gameState.fish * lastFishCoin + gameState.coins
+  const lastHeartbeatTime = getLastHeartbeatTime()
+  const shouldShowHeartbeat = isHeartbeatActive && lastHeartbeatTime > 0
 
   return (
     <main className="relative h-screen min-h-screen w-full flex-col p-3 pt-[0px]">
@@ -398,9 +401,9 @@ const GamePage = ({ params }) => {
         {isNetworkOffline && (
           <div className="rounded bg-yellow-500 px-2 py-1 text-xs text-white">재연결 중...</div>
         )}
-        {isHeartbeatActive && getLastHeartbeatTime() > 0 && (
+        {shouldShowHeartbeat && (
           <div className="rounded bg-green-500 px-2 py-1 text-xs text-white">
-            💓 {Math.floor((Date.now() - getLastHeartbeatTime()) / 1000)}s
+            💓 {Math.floor((Date.now() - lastHeartbeatTime) / 1000)}s
           </div>
         )}
       </div>

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -27,6 +27,9 @@ import {
   GameResultModel,
   GameInfoModel,
 } from '@/types/game'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
+import { useGameState } from '@/hooks/game/use-game-state'
+import { useHeartbeat } from '@/hooks/game/use-heartbeat'
 
 const GamePage = ({ params }) => {
   const { gameId } = params
@@ -61,9 +64,40 @@ const GamePage = ({ params }) => {
     resetResults,
   } = useGameStore()
   const { showToast } = useToastStore()
+  const { socket } = useSocket()
+  const { isOnline, isNetworkOffline } = useNetworkStatus()
+  const { gameData, saveGameData, getGameData } = useGameState()
+  const { startHeartbeat, stopHeartbeat, isHeartbeatActive, getLastHeartbeatTime } = useHeartbeat()
 
   useSocketNavigation(gameId)
-  const { socket } = useSocket()
+
+  useEffect(() => {
+    if (gameData.gameId && gameData.playerId && socket?.connected) {
+      console.log('💓 게임 하트비트 시작:', {
+        gameId: gameData.gameId,
+        playerId: gameData.playerId,
+      })
+      startHeartbeat(socket, getGameData, () => {
+        console.log('💔 하트비트 실패 - 동기화 요청')
+        socket.emit('request_sync', {
+          gameId: gameData.gameId,
+          playerId: gameData.playerId,
+        })
+      })
+    }
+
+    return () => {
+      console.log('💓 게임 하트비트 정지')
+      stopHeartbeat()
+    }
+  }, [
+    gameData.gameId,
+    gameData.playerId,
+    socket?.connected,
+    startHeartbeat,
+    stopHeartbeat,
+    getGameData,
+  ])
 
   useEffect(() => {
     socket.on('player_info', handlePlayerInitialize)
@@ -83,7 +117,6 @@ const GamePage = ({ params }) => {
     socket.on('player_left', handlePlayerLeft)
     socket.on('player_reconnected', handlePlayerReconnected)
 
-    // 초기 요청
     console.log('🚀 초기 게임 정보 요청:', { gameId })
     socket.emit('request_player_info', { gameId })
     socket.emit('request_first_round_hint', { gameId })
@@ -357,6 +390,20 @@ const GamePage = ({ params }) => {
   return (
     <main className="relative h-screen min-h-screen w-full flex-col p-3 pt-[0px]">
       <Background desktopImage={backgroundDesktopImage} mobileImage={backgroundMobileImage} />
+      {/* 🌐 연결 상태 표시 */}
+      <div className="fixed right-4 top-4 z-50 flex gap-2">
+        {!isOnline && (
+          <div className="bg-red-500 rounded px-2 py-1 text-xs text-white">오프라인</div>
+        )}
+        {isNetworkOffline && (
+          <div className="rounded bg-yellow-500 px-2 py-1 text-xs text-white">재연결 중...</div>
+        )}
+        {isHeartbeatActive && getLastHeartbeatTime() > 0 && (
+          <div className="rounded bg-green-500 px-2 py-1 text-xs text-white">
+            💓 {Math.floor((Date.now() - getLastHeartbeatTime()) / 1000)}s
+          </div>
+        )}
+      </div>
       <div className="mx-auto max-w-[420px] flex-col items-center justify-center p-3 md:pt-[50px]">
         <div className="my-4 flex justify-between">
           <div className="flex justify-start">

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -12,6 +12,9 @@ import PlayerGrid from '@/components/features/waiting/player-grid'
 import Background from '@/components/ui/background'
 import Toast from '@/components/ui/toast'
 import { gameConfig } from '@/constants/game'
+import { useGameState } from '@/hooks/game/use-game-state'
+import { useHeartbeat } from '@/hooks/game/use-heartbeat'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 import { useSocket } from '@/hooks/use-socket'
 import { useSocketNavigation } from '@/hooks/use-socket-navigation'
 import backgroundDesktopImage from '@/public/images/background-desktop-3.png'
@@ -27,9 +30,6 @@ import {
   GameResultModel,
   GameInfoModel,
 } from '@/types/game'
-import { useNetworkStatus } from '@/hooks/socket/use-network-status'
-import { useGameState } from '@/hooks/game/use-game-state'
-import { useHeartbeat } from '@/hooks/game/use-heartbeat'
 
 const GamePage = ({ params }) => {
   const { gameId } = params

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -80,11 +80,6 @@ const GamePage = ({ params }) => {
     const canStartHeartbeat = hasValidGameData && isSocketConnected
 
     if (canStartHeartbeat) {
-      console.log('💓 게임 하트비트 시작:', {
-        gameId,
-        playerId,
-      })
-
       startHeartbeat(socket, getGameData, () => {
         console.log('💔 하트비트 실패 - 동기화 요청')
         socket.emit('request_sync', {
@@ -95,7 +90,6 @@ const GamePage = ({ params }) => {
     }
 
     return () => {
-      console.log('💓 게임 하트비트 정지')
       stopHeartbeat()
     }
   }, [gameData.gameId, gameData.playerId, socket, startHeartbeat, stopHeartbeat, getGameData])
@@ -181,8 +175,6 @@ const GamePage = ({ params }) => {
     }
 
     if (gameInfo.nextRoundHint !== undefined || gameInfo.lastRoundHintResult !== undefined) {
-      console.log('🔄 힌트 상태 업데이트 전:', hints)
-
       setHints((prev) => {
         const newHints = {
           nextRoundHint:
@@ -192,7 +184,6 @@ const GamePage = ({ params }) => {
               ? gameInfo.lastRoundHintResult
               : prev.lastRoundHintResult,
         }
-        console.log('🔄 힌트 상태 업데이트 후:', newHints)
         return newHints
       })
     }
@@ -289,7 +280,6 @@ const GamePage = ({ params }) => {
   }
 
   const handleGameInfoUpdate = (gameInfo) => {
-    console.log('🔄 게임 정보 업데이트:', gameInfo)
     updateHintsAndGameState(gameInfo, 'updateGameInfo')
   }
 
@@ -298,7 +288,6 @@ const GamePage = ({ params }) => {
   }
 
   const handleRoundSync = (roundData) => {
-    console.log('🔄 라운드 동기화:', roundData)
     updateHintsAndGameState(
       {
         currentDay: roundData.currentRound,
@@ -317,13 +306,6 @@ const GamePage = ({ params }) => {
     if (syncData.gameInfo) {
       const { currentDay, currentFishPrice, nextRoundHint, lastRoundHintResult } = syncData.gameInfo
 
-      console.log('📊 동기화 데이터 적용:', {
-        currentRound: currentDay,
-        fishPrice: currentFishPrice,
-        hint: nextRoundHint,
-        hintResult: lastRoundHintResult,
-      })
-
       if (currentFishPrice !== undefined && currentFishPrice !== gameState.fishPrice) {
         setPrevFishPrice(gameState.fishPrice)
       }
@@ -341,13 +323,6 @@ const GamePage = ({ params }) => {
     }
 
     if (syncData.currentRound !== undefined) {
-      console.log('📊 라운드 동기화:', {
-        currentRound: syncData.currentRound,
-        fishPrice: syncData.fishPrice,
-        hint: syncData.hint,
-        hintResult: syncData.lastRoundResult,
-      })
-
       if (syncData.fishPrice !== undefined && syncData.fishPrice !== gameState.fishPrice) {
         setPrevFishPrice(gameState.fishPrice)
       }

--- a/app/result/[gameId]/page.tsx
+++ b/app/result/[gameId]/page.tsx
@@ -13,16 +13,15 @@ import coin from '@/public/images/coin.png'
 import useGameStore from '@/store/game'
 import useToastStore from '@/store/toast'
 import { GameResultModel } from '@/types/game'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 
 const ResultPage = ({ params }) => {
   const { gameId } = params
-
   const [currentUser, setCurrentUser] = useState<GameResultModel | null>(null)
-
+  const { socket } = useSocket()
+  const { isOnline } = useNetworkStatus()
   const { playerId: currentPlayerId, results: gameResults } = useGameStore()
   const { showToast } = useToastStore()
-  const { socket } = useSocket()
-
   useSocketNavigation(gameId)
 
   useEffect(() => {
@@ -57,6 +56,11 @@ ${gameResults
 
   return (
     <main className="flex min-h-dvh flex-col items-center justify-center">
+      {!isOnline && (
+        <div className="bg-red-500 fixed left-4 top-4 z-50 rounded px-3 py-1 text-sm text-white">
+          오프라인 - 공유 기능 제한됨
+        </div>
+      )}
       <div className="relative ml-1 flex h-[100px] w-[100px] items-center justify-center md:h-[150px] md:w-[150px]">
         <Image src={`/images/cat-${gameResults[0].character}.png`} alt="고양이" fill />
       </div>

--- a/app/result/[gameId]/page.tsx
+++ b/app/result/[gameId]/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 
 import LoadingPage from '@/app/loading'
 import LinkButton from '@/components/ui/link-button'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 import { useSocket } from '@/hooks/use-socket'
 import { useSocketNavigation } from '@/hooks/use-socket-navigation'
 import ConfettiComponent from '@/lib/confetti'
@@ -13,7 +14,6 @@ import coin from '@/public/images/coin.png'
 import useGameStore from '@/store/game'
 import useToastStore from '@/store/toast'
 import { GameResultModel } from '@/types/game'
-import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 
 const ResultPage = ({ params }) => {
   const { gameId } = params

--- a/app/setup/user-info/page.tsx
+++ b/app/setup/user-info/page.tsx
@@ -10,11 +10,11 @@ import { ArrowBackIcon } from '@/components/icons'
 import AvatarSelector from '@/components/ui/avatar-selector'
 import Button from '@/components/ui/button'
 import CountInput from '@/components/ui/count-input'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 import { useSocket } from '@/hooks/use-socket'
 import { validateNickname } from '@/lib/utils/nickname-validation'
 import useGameStore from '@/store/game'
 import useToastStore from '@/store/toast'
-import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 
 const UserInfoPage = () => {
   const AVATAR_COUNT = 6

--- a/app/setup/user-info/page.tsx
+++ b/app/setup/user-info/page.tsx
@@ -14,6 +14,7 @@ import { useSocket } from '@/hooks/use-socket'
 import { validateNickname } from '@/lib/utils/nickname-validation'
 import useGameStore from '@/store/game'
 import useToastStore from '@/store/toast'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 
 const UserInfoPage = () => {
   const AVATAR_COUNT = 6
@@ -25,6 +26,7 @@ const UserInfoPage = () => {
   const [errorMessage, setErrorMessage] = useState('')
 
   const { socket } = useSocket()
+  const { isOnline } = useNetworkStatus()
 
   const showToast = useToastStore((state) => state.showToast)
 
@@ -62,6 +64,11 @@ const UserInfoPage = () => {
   }
 
   const handleJoinClick = () => {
+    if (!isOnline) {
+      showToast('네트워크 연결을 확인해주세요', 'warning')
+      return
+    }
+
     const error = validateNickname(nickname)
     if (error) {
       setErrorMessage(error)
@@ -100,6 +107,12 @@ const UserInfoPage = () => {
       >
         <ArrowBackIcon className="text-gray-300 hover:text-gray-500" size={24} />
       </Link>
+      {!isOnline && (
+        <div className="bg-red-500 fixed right-4 top-4 z-50 rounded px-3 py-1 text-sm text-white">
+          연결 불안정
+        </div>
+      )}
+
       <AvatarSelector
         currentAvatarIndex={currentAvatarIndex}
         onPrevClick={handlePrevClick}

--- a/app/waiting/[gameId]/page.tsx
+++ b/app/waiting/[gameId]/page.tsx
@@ -10,6 +10,8 @@ import GameIdCopyButton from '@/components/features/waiting/game-id-copy-button'
 import PlayerGrid from '@/components/features/waiting/player-grid'
 import Background from '@/components/ui/background'
 import Button from '@/components/ui/button'
+import { useGameState } from '@/hooks/game/use-game-state'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
 import { useSocket } from '@/hooks/use-socket'
 import { useSocketNavigation } from '@/hooks/use-socket-navigation'
 import backgroundDesktopImage from '@/public/images/background-desktop-2.png'
@@ -17,8 +19,6 @@ import backgroundMobileImage from '@/public/images/background-mobile-2.png'
 import useGameStore from '@/store/game'
 import useToastStore from '@/store/toast'
 import { PlayerModel } from '@/types/game'
-import { useNetworkStatus } from '@/hooks/socket/use-network-status'
-import { useGameState } from '@/hooks/game/use-game-state'
 
 const WaitingPage = ({ params }) => {
   const { gameId = 'N09C14' } = params

--- a/app/waiting/[gameId]/page.tsx
+++ b/app/waiting/[gameId]/page.tsx
@@ -17,6 +17,8 @@ import backgroundMobileImage from '@/public/images/background-mobile-2.png'
 import useGameStore from '@/store/game'
 import useToastStore from '@/store/toast'
 import { PlayerModel } from '@/types/game'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
+import { useGameState } from '@/hooks/game/use-game-state'
 
 const WaitingPage = ({ params }) => {
   const { gameId = 'N09C14' } = params
@@ -29,8 +31,10 @@ const WaitingPage = ({ params }) => {
   const [isModalVisible, setIsModalVisible] = useState(false)
   const [isPreparingGame, setIsPreparingGame] = useState(false)
   const [notReturnedPlayersCount, setNotReturnedPlayersCount] = useState(0)
-
   const { socket } = useSocket()
+  const { isOnline } = useNetworkStatus()
+
+  const { saveGameData } = useGameState()
 
   const showToast = useToastStore((state) => state.showToast)
   const setGameRounds = useGameStore((state) => state.setGameRounds)
@@ -58,6 +62,7 @@ const WaitingPage = ({ params }) => {
         return
       }
 
+      saveGameData(gameId, playerId)
       setPlayers(players)
       setPlayerInfo(playerInfo)
     }
@@ -134,7 +139,11 @@ const WaitingPage = ({ params }) => {
   return (
     <main className="relative mx-auto min-h-screen w-full p-3 pt-[10px]">
       <Background desktopImage={backgroundDesktopImage} mobileImage={backgroundMobileImage} />
-
+      {!isOnline && (
+        <div className="bg-red-500 fixed left-4 top-4 z-50 rounded px-3 py-1 text-sm text-white">
+          연결 불안정
+        </div>
+      )}
       <div className="mx-auto mt-3 max-w-[420px] flex-col items-center justify-center gap-4 p-3 pb-44 md:pt-[50px]">
         <PlayerGrid players={players} />
         <div className="mt-3 flex flex-col items-center justify-center gap-3">

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -138,9 +138,15 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
   const handleTabSwitchExit = () => {
     const { gameId, playerId } = getGameData()
-    if (gameId && playerId && socket) {
+
+    const hasValidGameData = gameId && playerId
+    const hasSocket = socket
+    const canLeaveGame = hasValidGameData && hasSocket
+
+    if (canLeaveGame) {
       socket.emit('leave_game', { gameId, playerId, reason: 'tab_switch' })
     }
+
     forceExitGame('탭 전환으로 인해 게임에서 퇴장되었습니다.')
   }
 

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -208,7 +208,11 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   }
 
   const handleSyncFailedWrapper = (data: { error: string }) => {
-    handleSyncFailed(data, socket!, getGameData, showToast, forceExitGame)
+    if (socket) {
+      handleSyncFailed(data, socket, getGameData, showToast, forceExitGame)
+    } else {
+      console.error('Socket is not available to handle sync failure.')
+    }
   }
 
   const handlePlayerReconnected = ({ nickname }: { nickname: string }) => {

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -1,17 +1,18 @@
 'use client'
 
 import { createContext, useEffect, useRef, useState } from 'react'
+
 import { useRouter } from 'next/navigation'
 import { Socket } from 'socket.io-client'
 
 import ErrorModal from '@/components/ui/error-modal'
 import { SOCKET_ERROR_TYPES, SocketErrorType } from '@/constants/socket'
-import useToastStore from '@/store/toast'
-import { useSocketConnection } from '@/hooks/socket/use-socket-connection'
 import { useGameState } from '@/hooks/game/use-game-state'
 import { useNetworkStatus } from '@/hooks/socket/use-network-status'
+import { useSocketConnection } from '@/hooks/socket/use-socket-connection'
 import { useSocketReconnection } from '@/hooks/socket/use-socket-reconnection'
 import { useTabVisibility } from '@/hooks/socket/use-tab-visibility'
+import useToastStore from '@/store/toast'
 
 interface SocketContextModel {
   socket: Socket | null

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -54,7 +54,6 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const {
     isTabVisible,
     tabSwitchTimeLeft,
-    isTabSwitchModalShown,
     startTabSwitchWarning,
     stopTabSwitchTimers,
     handleTabReturn,

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -1,20 +1,22 @@
 'use client'
 
 import { createContext, useEffect, useRef, useState } from 'react'
-
 import { useRouter } from 'next/navigation'
-import { Socket, io } from 'socket.io-client'
+import { Socket } from 'socket.io-client'
 
 import ErrorModal from '@/components/ui/error-modal'
-import { SOCKET_ERROR_MESSAGES, SOCKET_ERROR_TYPES, SocketErrorType } from '@/constants/socket'
+import { SOCKET_ERROR_TYPES, SocketErrorType } from '@/constants/socket'
 import useToastStore from '@/store/toast'
-
-const RECONNECT_NOTIFICATION_INTERVAL = 1000
-const ERROR_MODAL_TIMEOUT = 10000
+import { useSocketConnection } from '@/hooks/socket/use-socket-connection'
+import { useGameState } from '@/hooks/game/use-game-state'
+import { useNetworkStatus } from '@/hooks/socket/use-network-status'
+import { useSocketReconnection } from '@/hooks/socket/use-socket-reconnection'
+import { useTabVisibility } from '@/hooks/socket/use-tab-visibility'
 
 interface SocketContextModel {
   socket: Socket | null
   isSocketConnected: boolean
+  isInGame: boolean
 }
 
 export const SocketContext = createContext<SocketContextModel | null>(null)
@@ -22,215 +24,169 @@ export const SocketContext = createContext<SocketContextModel | null>(null)
 const SocketProvider = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
   const { showToast } = useToastStore()
+  const {
+    socket,
+    isSocketConnected,
+    wasEverConnected,
+    createSocket,
+    handleConnect,
+    handleDisconnect,
+  } = useSocketConnection()
 
-  const [socket, setSocket] = useState<Socket | null>(null)
-  const [isSocketConnected, setIsSocketConnected] = useState(false)
-  const [isNetworkOffline, setIsNetworkOffline] = useState(false)
+  const { isInGame, saveGameData, clearGameData, getGameData } = useGameState()
+
+  const {
+    setOffline,
+    setOnline,
+    clearTimers,
+    registerNetworkListeners,
+    startReconnectNotifications,
+    stopReconnectNotifications,
+  } = useNetworkStatus()
+
+  const { handleGameStateSync, handleSyncComplete, handleSyncFailed, clearReconnectionState } =
+    useSocketReconnection()
+
+  const [tabSwitchCountdown, setTabSwitchCountdown] = useState<number>(0)
+
+  const {
+    isTabVisible,
+    tabSwitchTimeLeft,
+    isTabSwitchModalShown,
+    startTabSwitchWarning,
+    stopTabSwitchTimers,
+    handleTabReturn,
+    registerVisibilityListener,
+  } = useTabVisibility()
+
   const [errorType, setErrorType] = useState<SocketErrorType | null>(null)
-
-  const wasEverConnected = useRef(false)
-  const errorModalTimerRef = useRef<NodeJS.Timeout | null>(null)
-  const reconnectIntervalRef = useRef<NodeJS.Timeout | null>(null)
-  const shouldShowErrorModal = useRef(false)
-
-  const reconnectionInProgress = useRef(false)
-  const lastSyncRequestTime = useRef(0)
   const gameRestoreToastShown = useRef(false)
 
-  const gameDataRef = useRef<{
-    gameId: string | null
-    playerId: string | null
-  }>({
-    gameId: null,
-    playerId: null,
-  })
-
-  const saveGameData = (gameId: string, playerId: string) => {
-    gameDataRef.current = {
-      gameId,
-      playerId,
-    }
-    console.log('💾 게임 데이터 저장됨:', { gameId, playerId })
-  }
-
-  const getGameData = () => {
-    return {
-      gameId: gameDataRef.current.gameId,
-      playerId: gameDataRef.current.playerId,
-    }
-  }
-
-  const handleGameStateSync = (socketInstance: Socket) => {
-    const { gameId, playerId } = getGameData()
-
-    if (reconnectionInProgress.current) {
-      return
-    }
-
-    const now = Date.now()
-    if (now - lastSyncRequestTime.current < 3000) {
-      return
-    }
-
-    if (gameId && playerId && socketInstance.connected) {
-      console.log('📡 게임 상태 동기화 요청 전송됨')
-
-      reconnectionInProgress.current = true
-      lastSyncRequestTime.current = now
-
-      socketInstance.emit('request_sync', {
-        gameId,
-        playerId,
-        timestamp: now,
-      })
-
-      setTimeout(() => {
-        if (reconnectionInProgress.current) {
-          console.log('⏰ 동기화 타임아웃')
-          reconnectionInProgress.current = false
-        }
-      }, 10000)
-    }
+  const forceExitGame = (reason: string) => {
+    clearGameData()
+    clearReconnectionState()
+    showToast(reason, 'warning')
+    router.push('/')
   }
 
   const handleSocketConnect = (socketInstance: Socket) => {
-    setIsNetworkOffline(false)
-    shouldShowErrorModal.current = false
-
-    clearTimers()
+    setOnline()
     setErrorType(null)
 
-    if (wasEverConnected.current && !isSocketConnected) {
+    if (wasEverConnected && !isSocketConnected) {
       showToast('서버에 다시 연결되었습니다', 'connection')
+      gameRestoreToastShown.current = false
 
       const { gameId, playerId } = getGameData()
       if (gameId && playerId) {
         setTimeout(() => {
-          handleGameStateSync(socketInstance)
+          handleGameStateSync(socketInstance, getGameData)
         }, 1000)
       }
     }
 
-    setIsSocketConnected(true)
-    wasEverConnected.current = true
+    handleConnect()
   }
 
   const handleSocketDisconnect = () => {
-    setIsSocketConnected(false)
-    reconnectionInProgress.current = false
-    gameRestoreToastShown.current = false
+    handleDisconnect()
+    clearReconnectionState()
 
-    if (wasEverConnected.current) {
-      showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
-      setIsNetworkOffline(true)
-      shouldShowErrorModal.current = true
+    if (wasEverConnected) {
+      setOffline(() => {
+        setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
+        stopReconnectNotifications()
+      })
 
-      if (errorModalTimerRef.current) {
-        clearTimeout(errorModalTimerRef.current)
-      }
-
-      errorModalTimerRef.current = setTimeout(() => {
-        if (shouldShowErrorModal.current) {
-          setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
-
-          if (reconnectIntervalRef.current) {
-            clearInterval(reconnectIntervalRef.current)
-            reconnectIntervalRef.current = null
-          }
-        }
-      }, ERROR_MODAL_TIMEOUT)
+      startReconnectNotifications(showToast)
     }
   }
 
   const handleConnectionError = () => {
-    reconnectionInProgress.current = false
+    clearReconnectionState()
 
-    if (wasEverConnected.current) {
-      setIsNetworkOffline(true)
-      shouldShowErrorModal.current = true
-      showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
-
-      if (errorModalTimerRef.current) {
-        clearTimeout(errorModalTimerRef.current)
-      }
-
-      errorModalTimerRef.current = setTimeout(() => {
-        if (shouldShowErrorModal.current) {
-          setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
-
-          if (reconnectIntervalRef.current) {
-            clearInterval(reconnectIntervalRef.current)
-            reconnectIntervalRef.current = null
-          }
-        }
-      }, ERROR_MODAL_TIMEOUT)
-    }
-  }
-
-  const clearTimers = () => {
-    if (reconnectIntervalRef.current) {
-      clearInterval(reconnectIntervalRef.current)
-      reconnectIntervalRef.current = null
-    }
-
-    if (errorModalTimerRef.current) {
-      clearTimeout(errorModalTimerRef.current)
-      errorModalTimerRef.current = null
-    }
-  }
-
-  const handleSocketReconnectAttempt = () => {
-    reconnectionInProgress.current = false
-  }
-
-  const handleSocketReconnectSuccess = () => {
-    reconnectionInProgress.current = false
-  }
-
-  const handleSocketReconnectFailed = () => {
-    console.log('❌ 재연결 실패')
-    reconnectionInProgress.current = false
-    if (confirm('재연결에 실패했습니다. 페이지를 새로고침하시겠습니까?')) {
-      window.location.reload()
-    }
-  }
-
-  const handleSyncComplete = (gameSnapshot: any) => {
-    console.log('✅ 게임 상태 동기화 완료')
-
-    reconnectionInProgress.current = false
-    setIsNetworkOffline(false)
-
-    if (!gameRestoreToastShown.current) {
-      showToast('게임 상태가 복원되었습니다', 'connection')
-      gameRestoreToastShown.current = true
-    }
-
-    const { gameId, playerId } = getGameData()
-    if (gameSnapshot.gameId && gameId !== gameSnapshot.gameId) {
-      saveGameData(gameSnapshot.gameId, playerId || '')
-    }
-
-    window.dispatchEvent(
-      new CustomEvent('gameStateRestored', {
-        detail: gameSnapshot,
+    if (wasEverConnected) {
+      setOffline(() => {
+        setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
+        stopReconnectNotifications()
       })
-    )
+
+      startReconnectNotifications(showToast)
+    }
   }
 
-  const handleSyncFailed = ({ error }: { error: string }, socketInstance: Socket) => {
-    console.log('❌ 동기화 실패:', error)
-    reconnectionInProgress.current = false
-    showToast('게임 상태 복원에 실패했습니다', 'warning')
-
-    const { gameId, playerId } = getGameData()
-    if (gameId && playerId && socketInstance.connected) {
-      setTimeout(() => {
-        if (!reconnectionInProgress.current && socketInstance.connected) {
-          handleGameStateSync(socketInstance)
-        }
-      }, 3000)
+  const handleOnline = () => {
+    setOnline()
+    if (socket && !socket.connected) {
+      console.log('네트워크 복구 - 소켓 재연결 시도')
+      socket.connect()
     }
+  }
+
+  const handleOffline = () => {
+    setOffline(() => {
+      setErrorType(SOCKET_ERROR_TYPES.NETWORK_ERROR)
+    })
+  }
+
+  const handleTabSwitchWarning = () => {
+    setErrorType(SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING)
+    showToast('탭을 전환하셨습니다. 게임으로 돌아와 주세요.', 'warning')
+  }
+
+  const handleTabSwitchExit = () => {
+    const { gameId, playerId } = getGameData()
+    if (gameId && playerId && socket) {
+      socket.emit('leave_game', { gameId, playerId, reason: 'tab_switch' })
+    }
+    forceExitGame('탭 전환으로 인해 게임에서 퇴장되었습니다.')
+  }
+
+  const handleTabReturnWrapper = () => {
+    handleTabReturn()
+    setErrorType(null)
+    setTabSwitchCountdown(0)
+    showToast('게임으로 돌아오셨습니다.')
+  }
+
+  const enableTabSwitchDetection = () => {
+    if (!isInGame) return
+
+    const cleanup = registerVisibilityListener(
+      () => {
+        startTabSwitchWarning(handleTabSwitchWarning, handleTabSwitchExit)
+      },
+      () => {
+        if (errorType === SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING) {
+          handleTabReturnWrapper()
+        }
+      }
+    )
+
+    return cleanup
+  }
+
+  const disableTabSwitchDetection = () => {
+    stopTabSwitchTimers()
+    if (errorType === SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING) {
+      setErrorType(null)
+    }
+  }
+
+  const handleGameNotFound = ({ message }: { message: string }) => {
+    console.log('🎮 게임을 찾을 수 없음:', message)
+    forceExitGame(message || '게임을 찾을 수 없습니다.')
+  }
+
+  const handlePlayerKicked = ({ message }: { message: string }) => {
+    console.log('👢 플레이어가 추방됨:', message)
+    forceExitGame(message || '게임에서 추방되었습니다.')
+  }
+
+  const handleGameEnded = ({ message }: { message: string }) => {
+    console.log('🏁 게임이 종료됨:', message)
+    clearGameData()
+    showToast(message || '게임이 종료되었습니다.', 'warning')
   }
 
   const handleJoinSuccess = ({ gameId, playerId }: { gameId: string; playerId: string }) => {
@@ -239,158 +195,47 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
   const handlePlayerNotFound = ({ message }: { message: string }) => {
     console.log('❌ 플레이어를 찾을 수 없음:', message)
-
-    reconnectionInProgress.current = false
-
-    setTimeout(() => {
-      if (!reconnectionInProgress.current) {
-        gameDataRef.current = {
-          gameId: null,
-          playerId: null,
-        }
-
-        showToast(message, 'warning')
-
-        if (
-          window.location.pathname.includes('/game/') ||
-          window.location.pathname.includes('/waiting/')
-        ) {
-          router.push('/')
-        }
-      }
-    }, 1000)
+    forceExitGame(message || '플레이어를 찾을 수 없습니다.')
   }
 
-  const handleGameStateRestored = (gameState: any) => {
-    reconnectionInProgress.current = false
-    setIsNetworkOffline(false)
+  const handleSyncCompleteWrapper = (gameSnapshot: any) => {
+    handleSyncComplete(gameSnapshot, showToast)
 
-    window.dispatchEvent(
-      new CustomEvent('gameStateRestored', {
-        detail: gameState,
-      })
-    )
+    if (!gameRestoreToastShown.current) {
+      gameRestoreToastShown.current = true
+    }
+  }
+
+  const handleSyncFailedWrapper = (data: { error: string }) => {
+    handleSyncFailed(data, socket!, getGameData, showToast, forceExitGame)
   }
 
   const handlePlayerReconnected = ({ nickname }: { nickname: string }) => {
     showToast(`${nickname}님이 재연결되었습니다`, 'connection')
   }
 
-  const setupDebugFunctions = (socketInstance: Socket) => {
-    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-      window.debugSocket = {
-        status: () => {
-          const { gameId, playerId } = getGameData()
-          console.log('🔍 소켓 상태:', {
-            connected: socketInstance.connected,
-            gameId: gameId ? `${gameId.slice(0, 4)}***` : null,
-            playerId: playerId ? `${playerId.slice(0, 8)}***` : null,
-            reconnecting: reconnectionInProgress.current,
-          })
-        },
-        reconnect: () => {
-          console.log('🔧 수동 게임 상태 동기화 시도')
-          if (socketInstance.connected) {
-            reconnectionInProgress.current = false
-            handleGameStateSync(socketInstance)
-          } else {
-            console.log('❌ 소켓이 연결되지 않음')
-          }
-        },
-      }
-    }
-  }
-
-  const cleanupDebugFunctions = () => {
-    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-      delete window.debugSocket
-    }
-  }
+  useEffect(() => {
+    const cleanupNetwork = registerNetworkListeners(handleOnline, handleOffline)
+    return cleanupNetwork
+  }, [registerNetworkListeners])
 
   useEffect(() => {
-    const handleOnline = () => {
-      setIsNetworkOffline(false)
-      shouldShowErrorModal.current = false
-      reconnectionInProgress.current = false
-
-      if (errorModalTimerRef.current) {
-        clearTimeout(errorModalTimerRef.current)
-        errorModalTimerRef.current = null
-      }
-
-      if (socket && !socket.connected && wasEverConnected.current) {
-        socket.connect()
-
-        const { gameId, playerId } = getGameData()
-        if (gameId && playerId) {
-          setTimeout(() => {
-            if (socket.connected) {
-              handleGameStateSync(socket)
-            }
-          }, 1500)
-        }
-      }
+    if (errorType === SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING) {
+      setTabSwitchCountdown(tabSwitchTimeLeft)
     }
-
-    const handleOffline = () => {
-      setIsNetworkOffline(true)
-      shouldShowErrorModal.current = true
-      reconnectionInProgress.current = false
-
-      if (wasEverConnected.current) {
-        showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
-
-        if (errorModalTimerRef.current) {
-          clearTimeout(errorModalTimerRef.current)
-        }
-
-        errorModalTimerRef.current = setTimeout(() => {
-          if (shouldShowErrorModal.current) {
-            setErrorType(SOCKET_ERROR_TYPES.DISCONNECT)
-
-            if (reconnectIntervalRef.current) {
-              clearInterval(reconnectIntervalRef.current)
-              reconnectIntervalRef.current = null
-            }
-          }
-        }, ERROR_MODAL_TIMEOUT)
-      }
-    }
-
-    window.addEventListener('online', handleOnline)
-    window.addEventListener('offline', handleOffline)
-
-    return () => {
-      window.removeEventListener('online', handleOnline)
-      window.removeEventListener('offline', handleOffline)
-    }
-  }, [socket, showToast])
+  }, [tabSwitchTimeLeft, errorType])
 
   useEffect(() => {
-    if (isNetworkOffline && wasEverConnected.current && !errorType) {
-      if (reconnectIntervalRef.current) {
-        clearInterval(reconnectIntervalRef.current)
-      }
-
-      reconnectIntervalRef.current = setInterval(() => {
-        if (!errorType) {
-          showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
-        }
-      }, RECONNECT_NOTIFICATION_INTERVAL)
-    } else if ((!isNetworkOffline || errorType) && reconnectIntervalRef.current) {
-      clearInterval(reconnectIntervalRef.current)
-      reconnectIntervalRef.current = null
+    if (isInGame) {
+      const cleanup = enableTabSwitchDetection()
+      return cleanup
+    } else {
+      disableTabSwitchDetection()
     }
-
-    return () => {
-      if (reconnectIntervalRef.current) {
-        clearInterval(reconnectIntervalRef.current)
-      }
-    }
-  }, [isNetworkOffline, showToast, errorType])
+  }, [isInGame])
 
   useEffect(() => {
-    const socketInstance = io({
+    const socketInstance = createSocket({
       reconnection: true,
       reconnectionAttempts: 10,
       reconnectionDelay: 1000,
@@ -399,26 +244,18 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       forceNew: false,
     })
 
-    socketInstance.on('connect', () => {
-      handleSocketConnect(socketInstance)
-    })
-    socketInstance.on('disconnect', (reason) => {
-      console.log('💔 소켓 연결 끊김:', reason)
-      handleSocketDisconnect()
-    })
-    socketInstance.on('connect_error', (error) => {
-      console.log('❌ 연결 에러:', error)
-      handleConnectionError()
-    })
-    socketInstance.on('reconnect_attempt', handleSocketReconnectAttempt)
-    socketInstance.on('reconnect', handleSocketReconnectSuccess)
-    socketInstance.on('reconnect_failed', handleSocketReconnectFailed)
-    socketInstance.on('sync_complete', handleSyncComplete)
-    socketInstance.on('sync_failed', (data) => handleSyncFailed(data, socketInstance))
+    socketInstance.on('connect', () => handleSocketConnect(socketInstance))
+    socketInstance.on('disconnect', handleSocketDisconnect)
+    socketInstance.on('connect_error', handleConnectionError)
+    socketInstance.on('sync_complete', handleSyncCompleteWrapper)
+    socketInstance.on('sync_failed', handleSyncFailedWrapper)
     socketInstance.on('join_success', handleJoinSuccess)
     socketInstance.on('player_not_found', handlePlayerNotFound)
-    socketInstance.on('game_state_restored', handleGameStateRestored)
     socketInstance.on('player_reconnected', handlePlayerReconnected)
+    socketInstance.on('game_not_found', handleGameNotFound)
+    socketInstance.on('player_kicked', handlePlayerKicked)
+    socketInstance.on('game_ended', handleGameEnded)
+
     socketInstance.on('player_disconnected', ({ message }) => {
       showToast(message, 'warning')
     })
@@ -431,56 +268,79 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       showToast(message, 'warning')
     })
 
-    setSocket(socketInstance)
-    setIsSocketConnected(socketInstance.connected)
-
     if (!socketInstance.connected) {
       socketInstance.connect()
     }
 
-    setupDebugFunctions(socketInstance)
-
     return () => {
       clearTimers()
+      clearReconnectionState()
 
       socketInstance.off('connect')
       socketInstance.off('disconnect')
       socketInstance.off('connect_error')
-      socketInstance.off('reconnect_attempt')
-      socketInstance.off('reconnect')
-      socketInstance.off('reconnect_failed')
       socketInstance.off('sync_complete')
       socketInstance.off('sync_failed')
-      socketInstance.off('game_state_restored')
       socketInstance.off('player_reconnected')
       socketInstance.off('player_not_found')
       socketInstance.off('join_success')
+      socketInstance.off('game_not_found')
+      socketInstance.off('player_kicked')
+      socketInstance.off('game_ended')
       socketInstance.off('player_disconnected')
       socketInstance.off('player_removed')
       socketInstance.off('player_left')
 
       socketInstance.disconnect()
-
-      cleanupDebugFunctions()
     }
-  }, [showToast, router])
+  }, [])
 
-  const handleErrorModalClose = () => {
+  const handleReconnect = () => {
     setErrorType(null)
-    shouldShowErrorModal.current = false
-    router.push('/')
+
+    if (socket && !socket.connected) {
+      console.log('🔄 수동 재연결 시도')
+      socket.connect()
+    }
+  }
+
+  const getErrorActions = (errorType: SocketErrorType) => {
+    switch (errorType) {
+      case SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING:
+        return {
+          onPrimaryAction: handleTabSwitchExit,
+          onSecondaryAction: handleTabReturnWrapper,
+        }
+      case SOCKET_ERROR_TYPES.DISCONNECT:
+      case SOCKET_ERROR_TYPES.NETWORK_ERROR:
+        return {
+          onPrimaryAction: handleReconnect,
+          onSecondaryAction: () => setErrorType(null),
+        }
+      default:
+        return {
+          onPrimaryAction: () => router.push('/'),
+          onSecondaryAction: undefined,
+        }
+    }
+  }
+
+  const getCountdownMessage = (errorType: SocketErrorType) => {
+    if (errorType === SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING && tabSwitchCountdown > 0) {
+      return `${tabSwitchCountdown}초 후 자동으로 게임에서 나가집니다.`
+    }
+    return undefined
   }
 
   return (
-    <SocketContext.Provider value={{ socket, isSocketConnected }}>
+    <SocketContext.Provider value={{ socket, isSocketConnected, isInGame }}>
       {children}
       {errorType && (
         <ErrorModal
           isOpen={!!errorType}
-          title={SOCKET_ERROR_MESSAGES[errorType].title}
-          message={SOCKET_ERROR_MESSAGES[errorType].message}
-          buttonText="홈으로 이동"
-          onClick={handleErrorModalClose}
+          type={errorType}
+          countdownMessage={getCountdownMessage(errorType)}
+          {...getErrorActions(errorType)}
         />
       )}
     </SocketContext.Provider>

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -146,7 +146,7 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
       socket.emit('leave_game', { gameId, playerId, reason: 'tab_switch' })
     }
 
-    forceExitGame('탭 전환으로 인해 게임에서 퇴장되었습니다.')
+    forceExitGame('게임에서 퇴장되었습니다.')
   }
 
   const handleTabReturnWrapper = () => {
@@ -161,7 +161,11 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
 
     const cleanup = registerVisibilityListener(
       () => {
-        startTabSwitchWarning(handleTabSwitchWarning, handleTabSwitchExit)
+        setTimeout(() => {
+          if (document.visibilityState === 'hidden') {
+            startTabSwitchWarning(handleTabSwitchWarning, handleTabSwitchExit)
+          }
+        }, 100)
       },
       () => {
         if (errorType === SOCKET_ERROR_TYPES.TAB_SWITCH_WARNING) {

--- a/components/provider/socket-provider.tsx
+++ b/components/provider/socket-provider.tsx
@@ -13,6 +13,7 @@ import { useSocketConnection } from '@/hooks/socket/use-socket-connection'
 import { useSocketReconnection } from '@/hooks/socket/use-socket-reconnection'
 import { useTabVisibility } from '@/hooks/socket/use-tab-visibility'
 import useToastStore from '@/store/toast'
+import { GameSnapshotModel } from '@/types/game'
 
 interface SocketContextModel {
   socket: Socket | null
@@ -199,7 +200,7 @@ const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     forceExitGame(message || '플레이어를 찾을 수 없습니다.')
   }
 
-  const handleSyncCompleteWrapper = (gameSnapshot: any) => {
+  const handleSyncCompleteWrapper = (gameSnapshot: GameSnapshotModel) => {
     handleSyncComplete(gameSnapshot, showToast)
 
     if (!gameRestoreToastShown.current) {

--- a/components/ui/error-modal.tsx
+++ b/components/ui/error-modal.tsx
@@ -1,32 +1,58 @@
 import { ErrorOutlineIcon } from '@/components/icons'
 import Button from '@/components/ui/button'
 import Modal from '@/components/ui/modal'
+import { SOCKET_ERROR_MESSAGES, SOCKET_ERROR_BUTTONS, SocketErrorType } from '@/constants/socket'
 
 interface ErrorModalProps {
   isOpen: boolean
-  title: string
-  message: string
-  buttonText: string
-  onClick: () => void
+  type: SocketErrorType
+  onPrimaryAction: () => void
+  onSecondaryAction?: () => void
+  countdownMessage?: string
 }
 
-const ErrorModal = ({ isOpen, title, message, buttonText, onClick }: ErrorModalProps) => {
+const ErrorModal = ({
+  isOpen,
+  type,
+  onPrimaryAction,
+  onSecondaryAction,
+  countdownMessage,
+}: ErrorModalProps) => {
+  const messageConfig = SOCKET_ERROR_MESSAGES[type]
+  const buttonConfig = SOCKET_ERROR_BUTTONS[type]
+
+  const finalMessage = countdownMessage
+    ? `${messageConfig.message}\n${countdownMessage}`
+    : messageConfig.message
+
   return (
     <Modal isOpen={isOpen}>
       <div className="my-3 flex flex-col items-center">
         <ErrorOutlineIcon size={59} className="mb-4 text-red" />
-        <p className="mb-4 text-xl">{title}</p>
+        <p className="mb-4 text-xl">{messageConfig.title}</p>
         <p className="mb-7 text-center font-galmuri text-sm text-gray-400">
-          {message.split('\n').map((line, index) => (
+          {finalMessage.split('\n').map((line, index) => (
             <span key={index}>
               {line}
               <br />
             </span>
           ))}
         </p>
-        <Button onClick={onClick} className="w-[240px]">
-          {buttonText}
-        </Button>
+
+        {buttonConfig.showTwoButtons ? (
+          <div className="flex w-full max-w-[240px] gap-3">
+            <Button onClick={onSecondaryAction} variant="white" className="flex-1">
+              {buttonConfig.secondary}
+            </Button>
+            <Button onClick={onPrimaryAction} className="flex-1">
+              {buttonConfig.primary}
+            </Button>
+          </div>
+        ) : (
+          <Button onClick={onPrimaryAction} className="w-[240px]">
+            {buttonConfig.primary}
+          </Button>
+        )}
       </div>
     </Modal>
   )

--- a/constants/socket.ts
+++ b/constants/socket.ts
@@ -1,5 +1,7 @@
 export const SOCKET_ERROR_TYPES = {
   DISCONNECT: 'disconnect',
+  TAB_SWITCH_WARNING: 'tab_switch_warning',
+  NETWORK_ERROR: 'network_error',
 } as const
 
 export type SocketErrorType = (typeof SOCKET_ERROR_TYPES)[keyof typeof SOCKET_ERROR_TYPES]
@@ -8,5 +10,38 @@ export const SOCKET_ERROR_MESSAGES: Record<SocketErrorType, { title: string; mes
   disconnect: {
     title: '연결이 끊어졌습니다',
     message: '서버와의 연결이 끊어졌습니다. 네트워크 상태를 확인해주세요.',
+  },
+  tab_switch_warning: {
+    title: '잠시 자리를 비우셨네요',
+    message: '계속 사용하시겠습니까?',
+  },
+  network_error: {
+    title: '네트워크 오류',
+    message: '인터넷 연결을 확인해주세요.',
+  },
+}
+
+export const SOCKET_ERROR_BUTTONS: Record<
+  SocketErrorType,
+  {
+    primary: string
+    secondary?: string
+    showTwoButtons: boolean
+  }
+> = {
+  disconnect: {
+    primary: '재연결',
+    secondary: '나중에',
+    showTwoButtons: true,
+  },
+  tab_switch_warning: {
+    primary: '나가기',
+    secondary: '계속하기',
+    showTwoButtons: true,
+  },
+  network_error: {
+    primary: '재시도',
+    secondary: '확인',
+    showTwoButtons: true,
   },
 }

--- a/hooks/game/use-game-state.ts
+++ b/hooks/game/use-game-state.ts
@@ -1,0 +1,60 @@
+import { useState, useRef } from 'react'
+
+interface GameData {
+  gameId: string | null
+  playerId: string | null
+}
+
+interface UseGameStateReturn {
+  isInGame: boolean
+  gameData: GameData
+  saveGameData: (gameId: string, playerId: string) => void
+  clearGameData: () => void
+  getGameData: () => GameData
+  updateGameId: (gameId: string) => void
+  updatePlayerId: (playerId: string) => void
+}
+
+export const useGameState = (): UseGameStateReturn => {
+  const [isInGame, setIsInGame] = useState(false)
+  const gameDataRef = useRef<GameData>({
+    gameId: null,
+    playerId: null,
+  })
+
+  const saveGameData = (gameId: string, playerId: string) => {
+    gameDataRef.current = { gameId, playerId }
+    setIsInGame(true)
+    console.log('💾 게임 데이터 저장됨:', { gameId, playerId })
+  }
+
+  const clearGameData = () => {
+    gameDataRef.current = { gameId: null, playerId: null }
+    setIsInGame(false)
+    console.log('🗑️ 게임 데이터 초기화됨')
+  }
+
+  const getGameData = (): GameData => {
+    return { ...gameDataRef.current }
+  }
+
+  const updateGameId = (gameId: string) => {
+    gameDataRef.current.gameId = gameId
+    console.log('🆔 게임 ID 업데이트됨:', gameId)
+  }
+
+  const updatePlayerId = (playerId: string) => {
+    gameDataRef.current.playerId = playerId
+    console.log('👤 플레이어 ID 업데이트됨:', playerId)
+  }
+
+  return {
+    isInGame,
+    gameData: gameDataRef.current,
+    saveGameData,
+    clearGameData,
+    getGameData,
+    updateGameId,
+    updatePlayerId,
+  }
+}

--- a/hooks/game/use-heartbeat.ts
+++ b/hooks/game/use-heartbeat.ts
@@ -1,0 +1,115 @@
+import { useRef } from 'react'
+import { Socket } from 'socket.io-client'
+
+const HEARTBEAT_INTERVAL = 30000
+const HEARTBEAT_TIMEOUT = 10000
+
+interface HeartbeatData {
+  gameId: string
+  playerId: string
+  timestamp: number
+}
+
+interface UseHeartbeatReturn {
+  isHeartbeatActive: boolean
+  startHeartbeat: (
+    socket: Socket,
+    getGameData: () => { gameId: string | null; playerId: string | null },
+    onSyncRequired?: () => void
+  ) => void
+  stopHeartbeat: () => void
+  handleHeartbeatResponse: (data: { timestamp: number }) => void
+  getLastHeartbeatTime: () => number
+}
+
+export const useHeartbeat = (): UseHeartbeatReturn => {
+  const heartbeatIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const heartbeatTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const lastHeartbeatTime = useRef(0)
+  const isHeartbeatActive = useRef(false)
+
+  const startHeartbeat = (
+    socket: Socket,
+    getGameData: () => { gameId: string | null; playerId: string | null },
+    onSyncRequired?: () => void
+  ) => {
+    stopHeartbeat()
+
+    isHeartbeatActive.current = true
+    console.log('💓 Heartbeat 시작됨')
+
+    heartbeatIntervalRef.current = setInterval(() => {
+      const { gameId, playerId } = getGameData()
+
+      if (gameId && playerId && socket.connected) {
+        const now = Date.now()
+        lastHeartbeatTime.current = now
+
+        const heartbeatData: HeartbeatData = {
+          gameId,
+          playerId,
+          timestamp: now,
+        }
+
+        console.log('💓 Heartbeat 전송:', heartbeatData)
+        socket.emit('heartbeat', heartbeatData)
+
+        if (heartbeatTimeoutRef.current) {
+          clearTimeout(heartbeatTimeoutRef.current)
+        }
+
+        heartbeatTimeoutRef.current = setTimeout(() => {
+          console.log('💔 Heartbeat 응답 없음 - 연결 상태 확인 필요')
+          if (socket.connected && onSyncRequired) {
+            onSyncRequired()
+          }
+        }, HEARTBEAT_TIMEOUT)
+      } else {
+        console.log('💔 Heartbeat 조건 불충족:', {
+          gameId,
+          playerId,
+          connected: socket.connected,
+        })
+      }
+    }, HEARTBEAT_INTERVAL)
+  }
+
+  const stopHeartbeat = () => {
+    isHeartbeatActive.current = false
+
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current)
+      heartbeatIntervalRef.current = null
+    }
+
+    if (heartbeatTimeoutRef.current) {
+      clearTimeout(heartbeatTimeoutRef.current)
+      heartbeatTimeoutRef.current = null
+    }
+
+    console.log('💓 Heartbeat 중지됨')
+  }
+
+  const handleHeartbeatResponse = ({ timestamp }: { timestamp: number }) => {
+    const now = Date.now()
+    const latency = now - timestamp
+    console.log('💚 Heartbeat 응답 수신 (지연시간:', latency, 'ms)')
+
+    if (heartbeatTimeoutRef.current) {
+      clearTimeout(heartbeatTimeoutRef.current)
+      heartbeatTimeoutRef.current = null
+    }
+  }
+
+  const getLastHeartbeatTime = () => {
+    return lastHeartbeatTime.current
+  }
+
+  return {
+    isHeartbeatActive: isHeartbeatActive.current,
+    startHeartbeat,
+    stopHeartbeat,
+    handleHeartbeatResponse,
+    getLastHeartbeatTime,
+  }
+}

--- a/hooks/game/use-heartbeat.ts
+++ b/hooks/game/use-heartbeat.ts
@@ -41,7 +41,12 @@ export const useHeartbeat = (): UseHeartbeatReturn => {
     heartbeatIntervalRef.current = setInterval(() => {
       const { gameId, playerId } = getGameData()
 
-      if (gameId && playerId && socket.connected) {
+      // 조건을 명확하게 분리
+      const hasValidGameData = gameId && playerId
+      const isSocketConnected = socket.connected
+      const canSendHeartbeat = hasValidGameData && isSocketConnected
+
+      if (canSendHeartbeat) {
         const now = Date.now()
         lastHeartbeatTime.current = now
 
@@ -60,7 +65,8 @@ export const useHeartbeat = (): UseHeartbeatReturn => {
 
         heartbeatTimeoutRef.current = setTimeout(() => {
           console.log('💔 Heartbeat 응답 없음 - 연결 상태 확인 필요')
-          if (socket.connected && onSyncRequired) {
+          const isStillConnected = socket.connected
+          if (isStillConnected && onSyncRequired) {
             onSyncRequired()
           }
         }, HEARTBEAT_TIMEOUT)

--- a/hooks/game/use-heartbeat.ts
+++ b/hooks/game/use-heartbeat.ts
@@ -36,7 +36,6 @@ export const useHeartbeat = (): UseHeartbeatReturn => {
     stopHeartbeat()
 
     isHeartbeatActive.current = true
-    console.log('💓 Heartbeat 시작됨')
 
     heartbeatIntervalRef.current = setInterval(() => {
       const { gameId, playerId } = getGameData()
@@ -56,7 +55,6 @@ export const useHeartbeat = (): UseHeartbeatReturn => {
           timestamp: now,
         }
 
-        console.log('💓 Heartbeat 전송:', heartbeatData)
         socket.emit('heartbeat', heartbeatData)
 
         if (heartbeatTimeoutRef.current) {
@@ -64,7 +62,6 @@ export const useHeartbeat = (): UseHeartbeatReturn => {
         }
 
         heartbeatTimeoutRef.current = setTimeout(() => {
-          console.log('💔 Heartbeat 응답 없음 - 연결 상태 확인 필요')
           const isStillConnected = socket.connected
           if (isStillConnected && onSyncRequired) {
             onSyncRequired()
@@ -92,8 +89,6 @@ export const useHeartbeat = (): UseHeartbeatReturn => {
       clearTimeout(heartbeatTimeoutRef.current)
       heartbeatTimeoutRef.current = null
     }
-
-    console.log('💓 Heartbeat 중지됨')
   }
 
   const handleHeartbeatResponse = ({ timestamp }: { timestamp: number }) => {

--- a/hooks/socket/use-network-status.ts
+++ b/hooks/socket/use-network-status.ts
@@ -1,0 +1,151 @@
+import { useState, useRef, useEffect } from 'react'
+
+const ERROR_MODAL_TIMEOUT = 10000
+const RECONNECT_NOTIFICATION_INTERVAL = 1000
+
+interface UseNetworkStatusReturn {
+  isOnline: boolean
+  isNetworkOffline: boolean
+  shouldShowErrorModal: boolean
+  setOffline: (onErrorModal?: () => void) => void
+  setOnline: () => void
+  clearTimers: () => void
+  startReconnectNotifications: (showToast: (msg: string, type: string) => void) => void
+  stopReconnectNotifications: () => void
+  registerNetworkListeners: (onOnline: () => void, onOffline: () => void) => () => void
+}
+
+export const useNetworkStatus = (): UseNetworkStatusReturn => {
+  const [isOnline, setIsOnline] = useState(true)
+  const [isNetworkOffline, setIsNetworkOffline] = useState(false)
+
+  const errorModalTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const reconnectIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const shouldShowErrorModal = useRef(false)
+
+  useEffect(() => {
+    if (typeof navigator !== 'undefined') {
+      setIsOnline(navigator.onLine)
+    }
+  }, [])
+
+  const setOffline = (onErrorModal?: () => void) => {
+    setIsNetworkOffline(true)
+    shouldShowErrorModal.current = true
+
+    console.log('🔴 네트워크 오프라인 상태로 변경')
+
+    if (errorModalTimerRef.current) {
+      clearTimeout(errorModalTimerRef.current)
+    }
+
+    if (onErrorModal) {
+      errorModalTimerRef.current = setTimeout(() => {
+        if (shouldShowErrorModal.current) {
+          console.log('🚨 에러 모달 표시 시간 도달')
+          onErrorModal()
+        }
+      }, ERROR_MODAL_TIMEOUT)
+    }
+  }
+
+  const setOnline = () => {
+    setIsNetworkOffline(false)
+    shouldShowErrorModal.current = false
+
+    console.log('🟢 네트워크 온라인 상태로 변경')
+
+    if (errorModalTimerRef.current) {
+      clearTimeout(errorModalTimerRef.current)
+      errorModalTimerRef.current = null
+    }
+
+    if (reconnectIntervalRef.current) {
+      clearInterval(reconnectIntervalRef.current)
+      reconnectIntervalRef.current = null
+    }
+  }
+
+  const clearTimers = () => {
+    shouldShowErrorModal.current = false
+
+    if (errorModalTimerRef.current) {
+      clearTimeout(errorModalTimerRef.current)
+      errorModalTimerRef.current = null
+    }
+
+    if (reconnectIntervalRef.current) {
+      clearInterval(reconnectIntervalRef.current)
+      reconnectIntervalRef.current = null
+    }
+
+    console.log('네트워크 상태 타이머 모두 정리됨')
+  }
+
+  const startReconnectNotifications = (showToast: (msg: string, type: string) => void) => {
+    if (reconnectIntervalRef.current) {
+      clearInterval(reconnectIntervalRef.current)
+    }
+
+    console.log('재연결 알림 시작')
+
+    reconnectIntervalRef.current = setInterval(() => {
+      if (isNetworkOffline && !shouldShowErrorModal.current) {
+        showToast('연결이 불안정합니다. 다시 연결 중...', 'warning')
+      }
+    }, RECONNECT_NOTIFICATION_INTERVAL)
+  }
+
+  const stopReconnectNotifications = () => {
+    if (reconnectIntervalRef.current) {
+      clearInterval(reconnectIntervalRef.current)
+      reconnectIntervalRef.current = null
+      console.log('재연결 알림 중지')
+    }
+  }
+
+  const registerNetworkListeners = (onOnline: () => void, onOffline: () => void) => {
+    if (typeof window === 'undefined') {
+      console.log('서버 환경: 네트워크 이벤트 리스너 등록 불가')
+      return () => {}
+    }
+
+    const handleOnline = () => {
+      setIsOnline(true)
+      console.log('브라우저: 온라인 이벤트')
+      onOnline()
+    }
+
+    const handleOffline = () => {
+      setIsOnline(false)
+      console.log('브라우저: 오프라인 이벤트')
+      onOffline()
+    }
+
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      clearTimers()
+    }
+  }, [clearTimers])
+
+  return {
+    isOnline,
+    isNetworkOffline,
+    shouldShowErrorModal: shouldShowErrorModal.current,
+    setOffline,
+    setOnline,
+    clearTimers,
+    startReconnectNotifications,
+    stopReconnectNotifications,
+    registerNetworkListeners,
+  }
+}

--- a/hooks/socket/use-socket-connection.ts
+++ b/hooks/socket/use-socket-connection.ts
@@ -1,0 +1,91 @@
+import { useState, useRef } from 'react'
+import { Socket, io } from 'socket.io-client'
+
+interface SocketConnectionOptions {
+  reconnection?: boolean
+  reconnectionAttempts?: number
+  reconnectionDelay?: number
+  reconnectionDelayMax?: number
+  timeout?: number
+  forceNew?: boolean
+}
+
+interface UseSocketConnectionReturn {
+  socket: Socket | null
+  isSocketConnected: boolean
+  wasEverConnected: boolean
+  createSocket: (options?: SocketConnectionOptions) => Socket
+  handleConnect: () => void
+  handleDisconnect: () => void
+  disconnect: () => void
+  reconnect: () => void
+}
+
+export const useSocketConnection = (): UseSocketConnectionReturn => {
+  const [socket, setSocket] = useState<Socket | null>(null)
+  const [isSocketConnected, setIsSocketConnected] = useState(false)
+  const wasEverConnected = useRef(false)
+
+  const createSocket = (options?: SocketConnectionOptions): Socket => {
+    if (socket) {
+      socket.disconnect()
+    }
+
+    const defaultOptions: SocketConnectionOptions = {
+      reconnection: true,
+      reconnectionAttempts: 10,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
+      timeout: 15000,
+      forceNew: false,
+    }
+
+    const socketInstance = io({
+      ...defaultOptions,
+      ...options,
+    })
+
+    setSocket(socketInstance)
+    setIsSocketConnected(socketInstance.connected)
+
+    return socketInstance
+  }
+
+  const handleConnect = () => {
+    setIsSocketConnected(true)
+    wasEverConnected.current = true
+    console.log('🔌 Socket 연결됨')
+  }
+
+  const handleDisconnect = () => {
+    setIsSocketConnected(false)
+    console.log('🔌 Socket 연결 해제됨')
+  }
+
+  const disconnect = () => {
+    if (socket) {
+      socket.disconnect()
+      setSocket(null)
+      setIsSocketConnected(false)
+      console.log('🔌 Socket 수동 연결 해제')
+    }
+  }
+
+  const reconnect = () => {
+    if (socket && !socket.connected) {
+      console.log('🔄 Socket 재연결 시도')
+      socket.connect()
+    }
+  }
+
+  return {
+    socket,
+    isSocketConnected,
+    wasEverConnected: wasEverConnected.current,
+    createSocket,
+    handleConnect,
+    handleDisconnect,
+    disconnect,
+    reconnect,
+  }
+}

--- a/hooks/socket/use-socket-reconnection.ts
+++ b/hooks/socket/use-socket-reconnection.ts
@@ -18,7 +18,11 @@ export const useSocketReconnection = <T>() => {
     const now = Date.now()
     if (now - lastSyncRequestTime.current < 3000) return
 
-    if (gameId && playerId && socket.connected) {
+    const hasValidGameData = gameId && playerId
+    const isSocketConnected = socket.connected
+    const canRequestSync = hasValidGameData && isSocketConnected
+
+    if (canRequestSync) {
       console.log('📡 게임 상태 동기화 요청 전송됨')
 
       reconnectionInProgress.current = true
@@ -70,7 +74,11 @@ export const useSocketReconnection = <T>() => {
     showToast('게임 상태 복원에 실패했습니다', 'warning')
 
     const { gameId, playerId } = getGameData()
-    if (gameId && playerId && socket.connected) {
+    const hasValidGameData = gameId && playerId
+    const isSocketConnected = socket.connected
+    const canRetrySync = hasValidGameData && isSocketConnected
+
+    if (canRetrySync) {
       setTimeout(() => {
         if (!reconnectionInProgress.current && socket.connected) {
           handleGameStateSync(socket, getGameData)

--- a/hooks/socket/use-socket-reconnection.ts
+++ b/hooks/socket/use-socket-reconnection.ts
@@ -1,0 +1,98 @@
+import { useRef } from 'react'
+import { Socket } from 'socket.io-client'
+
+export const useSocketReconnection = () => {
+  const reconnectionInProgress = useRef(false)
+  const lastSyncRequestTime = useRef(0)
+  const gameRestoreToastShown = useRef(false)
+
+  const handleGameStateSync = (
+    socket: Socket,
+    getGameData: () => { gameId: string | null; playerId: string | null }
+  ) => {
+    const { gameId, playerId } = getGameData()
+
+    if (reconnectionInProgress.current) return
+
+    const now = Date.now()
+    if (now - lastSyncRequestTime.current < 3000) return
+
+    if (gameId && playerId && socket.connected) {
+      console.log('📡 게임 상태 동기화 요청 전송됨')
+
+      reconnectionInProgress.current = true
+      lastSyncRequestTime.current = now
+
+      socket.emit('request_sync', { gameId, playerId, timestamp: now })
+
+      setTimeout(() => {
+        if (reconnectionInProgress.current) {
+          console.log('⏰ 동기화 타임아웃')
+          reconnectionInProgress.current = false
+        }
+      }, 10000)
+    }
+  }
+
+  const handleSyncComplete = (
+    gameSnapshot: any,
+    showToast: (msg: string, type: string) => void
+  ) => {
+    console.log('✅ 게임 상태 동기화 완료')
+
+    reconnectionInProgress.current = false
+
+    if (!gameRestoreToastShown.current) {
+      showToast('게임 상태가 복원되었습니다', 'connection')
+      gameRestoreToastShown.current = true
+    }
+
+    window.dispatchEvent(
+      new CustomEvent('gameStateRestored', {
+        detail: gameSnapshot,
+      })
+    )
+  }
+
+  const handleSyncFailed = (
+    { error }: { error: string },
+    socket: Socket,
+    getGameData: () => { gameId: string | null; playerId: string | null },
+    showToast: (msg: string, type: string) => void,
+    forceExitGame: (reason: string) => void
+  ) => {
+    console.log('❌ 동기화 실패:', error)
+    reconnectionInProgress.current = false
+
+    if (error.includes('not found') || error.includes('찾을 수 없')) {
+      forceExitGame('게임 상태를 복원할 수 없습니다.')
+      return
+    }
+
+    showToast('게임 상태 복원에 실패했습니다', 'warning')
+
+    const { gameId, playerId } = getGameData()
+    if (gameId && playerId && socket.connected) {
+      setTimeout(() => {
+        if (!reconnectionInProgress.current && socket.connected) {
+          handleGameStateSync(socket, getGameData)
+        }
+      }, 3000)
+    }
+  }
+
+  const clearReconnectionState = () => {
+    reconnectionInProgress.current = false
+    gameRestoreToastShown.current = false
+  }
+
+  return {
+    reconnectionInProgress: reconnectionInProgress.current,
+    handleGameStateSync,
+    handleSyncComplete,
+    handleSyncFailed,
+    clearReconnectionState,
+  }
+}
+
+

--- a/hooks/socket/use-socket-reconnection.ts
+++ b/hooks/socket/use-socket-reconnection.ts
@@ -1,7 +1,8 @@
 import { useRef } from 'react'
+
 import { Socket } from 'socket.io-client'
 
-export const useSocketReconnection = () => {
+export const useSocketReconnection = <T>() => {
   const reconnectionInProgress = useRef(false)
   const lastSyncRequestTime = useRef(0)
   const gameRestoreToastShown = useRef(false)
@@ -34,10 +35,7 @@ export const useSocketReconnection = () => {
     }
   }
 
-  const handleSyncComplete = (
-    gameSnapshot: any,
-    showToast: (msg: string, type: string) => void
-  ) => {
+  const handleSyncComplete = (gameSnapshot: T, showToast: (msg: string, type: string) => void) => {
     console.log('✅ 게임 상태 동기화 완료')
 
     reconnectionInProgress.current = false
@@ -94,5 +92,3 @@ export const useSocketReconnection = () => {
     clearReconnectionState,
   }
 }
-
-

--- a/hooks/socket/use-tab-visibility.ts
+++ b/hooks/socket/use-tab-visibility.ts
@@ -39,7 +39,6 @@ export const useTabVisibility = (): UseTabVisibilityReturn => {
 
     tabSwitchWarningTimerRef.current = setTimeout(() => {
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
-        console.log('모바일: 탭 전환 지속 - 확인 모달 표시')
         isTabSwitchModalShown.current = true
         onWarning()
         setTabSwitchTimeLeft(60)
@@ -108,8 +107,6 @@ export const useTabVisibility = (): UseTabVisibilityReturn => {
     isTabSwitchModalShown.current = false
     isTabReturning.current = false
     setTabSwitchTimeLeft(60)
-
-    console.log('탭 전환 타이머 모두 정지됨')
   }
 
   const handleTabReturn = () => {

--- a/hooks/socket/use-tab-visibility.ts
+++ b/hooks/socket/use-tab-visibility.ts
@@ -58,11 +58,12 @@ export const useTabVisibility = (): UseTabVisibilityReturn => {
     console.log('모바일: 60초 후 최종 자동 퇴장됩니다')
 
     tabSwitchFinalTimerRef.current = setTimeout(() => {
-      if (
-        isTabSwitchModalShown.current &&
-        typeof document !== 'undefined' &&
-        document.visibilityState === 'hidden'
-      ) {
+      const isModalShown = isTabSwitchModalShown.current
+      const isDocumentAvailable = typeof document !== 'undefined'
+      const isTabHidden = isDocumentAvailable && document.visibilityState === 'hidden'
+      const shouldFinalExit = isModalShown && isTabHidden
+
+      if (shouldFinalExit) {
         console.log('모바일: 최종 시간 초과 - 강제 퇴장')
         onFinalExit()
       }

--- a/hooks/socket/use-tab-visibility.ts
+++ b/hooks/socket/use-tab-visibility.ts
@@ -1,0 +1,174 @@
+import { useState, useEffect, useRef } from 'react'
+import { isMobile } from '@/lib/utils/device'
+
+const TAB_SWITCH_WARNING_TIMEOUT = 10000
+const TAB_SWITCH_FINAL_TIMEOUT = 60000
+
+interface UseTabVisibilityReturn {
+  isTabVisible: boolean
+  tabSwitchTimeLeft: number
+  isTabSwitchModalShown: boolean
+  isTabReturning: boolean
+  startTabSwitchWarning: (onWarning: () => void, onFinalExit: () => void) => void
+  stopTabSwitchTimers: () => void
+  handleTabReturn: () => void
+  registerVisibilityListener: (onTabHidden: () => void, onTabVisible: () => void) => () => void
+}
+
+export const useTabVisibility = (): UseTabVisibilityReturn => {
+  const [isTabVisible, setIsTabVisible] = useState(true)
+  const [tabSwitchTimeLeft, setTabSwitchTimeLeft] = useState(60)
+
+  const tabSwitchWarningTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const tabSwitchFinalTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const tabSwitchCountdownRef = useRef<NodeJS.Timeout | null>(null)
+  const isTabSwitchModalShown = useRef(false)
+  const isTabReturning = useRef(false)
+
+  const startTabSwitchWarning = (onWarning: () => void, onFinalExit: () => void) => {
+    if (!isMobile()) {
+      console.log('PC 환경: 탭 전환 경고 무시')
+      return
+    }
+
+    if (tabSwitchWarningTimerRef.current) {
+      clearTimeout(tabSwitchWarningTimerRef.current)
+    }
+
+    console.log('모바일: 10초 후 확인 모달이 표시됩니다')
+
+    tabSwitchWarningTimerRef.current = setTimeout(() => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        console.log('모바일: 탭 전환 지속 - 확인 모달 표시')
+        isTabSwitchModalShown.current = true
+        onWarning()
+        setTabSwitchTimeLeft(60)
+
+        startFinalExitTimer(onFinalExit)
+        startCountdown()
+      }
+    }, TAB_SWITCH_WARNING_TIMEOUT)
+  }
+
+  const startFinalExitTimer = (onFinalExit: () => void) => {
+    if (tabSwitchFinalTimerRef.current) {
+      clearTimeout(tabSwitchFinalTimerRef.current)
+    }
+
+    console.log('모바일: 60초 후 최종 자동 퇴장됩니다')
+
+    tabSwitchFinalTimerRef.current = setTimeout(() => {
+      if (
+        isTabSwitchModalShown.current &&
+        typeof document !== 'undefined' &&
+        document.visibilityState === 'hidden'
+      ) {
+        console.log('모바일: 최종 시간 초과 - 강제 퇴장')
+        onFinalExit()
+      }
+    }, TAB_SWITCH_FINAL_TIMEOUT)
+  }
+
+  const startCountdown = () => {
+    if (tabSwitchCountdownRef.current) {
+      clearInterval(tabSwitchCountdownRef.current)
+    }
+
+    tabSwitchCountdownRef.current = setInterval(() => {
+      setTabSwitchTimeLeft((prev) => {
+        if (prev <= 1) {
+          if (tabSwitchCountdownRef.current) {
+            clearInterval(tabSwitchCountdownRef.current)
+            tabSwitchCountdownRef.current = null
+          }
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }
+
+  const stopTabSwitchTimers = () => {
+    if (tabSwitchWarningTimerRef.current) {
+      clearTimeout(tabSwitchWarningTimerRef.current)
+      tabSwitchWarningTimerRef.current = null
+    }
+
+    if (tabSwitchFinalTimerRef.current) {
+      clearTimeout(tabSwitchFinalTimerRef.current)
+      tabSwitchFinalTimerRef.current = null
+    }
+
+    if (tabSwitchCountdownRef.current) {
+      clearInterval(tabSwitchCountdownRef.current)
+      tabSwitchCountdownRef.current = null
+    }
+
+    isTabSwitchModalShown.current = false
+    isTabReturning.current = false
+    setTabSwitchTimeLeft(60)
+
+    console.log('탭 전환 타이머 모두 정지됨')
+  }
+
+  const handleTabReturn = () => {
+    stopTabSwitchTimers()
+    isTabReturning.current = true
+
+    setTimeout(() => {
+      isTabReturning.current = false
+    }, 0)
+
+    console.log('탭 복귀 처리 완료')
+  }
+
+  const registerVisibilityListener = (onTabHidden: () => void, onTabVisible: () => void) => {
+    const handleVisibilityChange = () => {
+      if (typeof document === 'undefined') return
+
+      const visible = document.visibilityState === 'visible'
+      setIsTabVisible(visible)
+
+      if (visible) {
+        console.log('탭 보임')
+        onTabVisible()
+      } else {
+        console.log('탭 숨김')
+        onTabHidden()
+      }
+    }
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+    }
+
+    return () => {
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      setIsTabVisible(!document.hidden)
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      stopTabSwitchTimers()
+    }
+  }, [stopTabSwitchTimers])
+
+  return {
+    isTabVisible,
+    tabSwitchTimeLeft,
+    isTabSwitchModalShown: isTabSwitchModalShown.current,
+    isTabReturning: isTabReturning.current,
+    startTabSwitchWarning,
+    stopTabSwitchTimers,
+    handleTabReturn,
+    registerVisibilityListener,
+  }
+}

--- a/hooks/use-socket-navigation.ts
+++ b/hooks/use-socket-navigation.ts
@@ -1,23 +1,24 @@
 import { useEffect, useRef } from 'react'
-
 import { useRouter } from 'next/navigation'
-
-import { isMobile } from '@/lib/utils/device'
-
 import { useSocket } from './use-socket'
 
-export const useSocketNavigation = (gameId) => {
-  const timeoutId = useRef(null)
-  const router = useRouter()
+const AUTO_EXIT_TIMEOUT = 5000
 
+interface UseSocketNavigationReturn {
+  startExitTimer: () => void
+  stopExitTimer: () => void
+}
+
+export const useSocketNavigation = (gameId: string | null): UseSocketNavigationReturn => {
+  const router = useRouter()
   const { socket } = useSocket()
+  const timeoutId = useRef<NodeJS.Timeout | null>(null)
 
   const cleanupAndRedirect = () => {
     if (gameId && socket) {
       socket.emit('leave_game', { gameId })
       socket.emit('user_disconnect', { gameId })
     }
-
     router.push('/')
   }
 
@@ -28,7 +29,7 @@ export const useSocketNavigation = (gameId) => {
 
     timeoutId.current = setTimeout(() => {
       cleanupAndRedirect()
-    }, 5000)
+    }, AUTO_EXIT_TIMEOUT)
   }
 
   const stopExitTimer = () => {
@@ -43,13 +44,18 @@ export const useSocketNavigation = (gameId) => {
       return
     }
 
-    window.history.pushState(null, '', window.location.pathname)
+    if (typeof window !== 'undefined') {
+      window.history.pushState(null, '', window.location.pathname)
+    }
 
     const handlePopState = (event: PopStateEvent) => {
       event.preventDefault()
-      if (window.confirm('뒤로가기 시, 게임에 다시 입장할 수 없습니다.')) {
+      if (
+        typeof window !== 'undefined' &&
+        window.confirm('뒤로가기 시, 게임에 다시 입장할 수 없습니다.')
+      ) {
         cleanupAndRedirect()
-      } else {
+      } else if (typeof window !== 'undefined') {
         window.history.pushState(null, '', window.location.pathname)
       }
     }
@@ -64,38 +70,29 @@ export const useSocketNavigation = (gameId) => {
       return ''
     }
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden') {
-        if (!socket?.connected) {
-          cleanupAndRedirect()
-        } else {
-          startExitTimer()
-        }
-      } else if (document.visibilityState === 'visible') {
-        stopExitTimer()
-      }
-    }
-
-    window.addEventListener('popstate', handlePopState)
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    if (isMobile()) {
-      document.addEventListener('visibilitychange', handleVisibilityChange)
+    if (typeof window !== 'undefined') {
+      window.addEventListener('popstate', handlePopState)
+      window.addEventListener('beforeunload', handleBeforeUnload)
     }
 
     return () => {
       stopExitTimer()
 
-      window.removeEventListener('popstate', handlePopState)
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-      if (isMobile()) {
-        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('popstate', handlePopState)
+        window.removeEventListener('beforeunload', handleBeforeUnload)
       }
     }
-  }, [gameId, socket])
+  }, [gameId, socket, cleanupAndRedirect, stopExitTimer])
 
   useEffect(() => {
     return () => {
       stopExitTimer()
     }
-  }, [])
+  }, [stopExitTimer])
+
+  return {
+    startExitTimer,
+    stopExitTimer,
+  }
 }

--- a/hooks/use-socket-navigation.ts
+++ b/hooks/use-socket-navigation.ts
@@ -61,7 +61,10 @@ export const useSocketNavigation = (gameId: string | null): UseSocketNavigationR
     }
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (gameId && socket && socket.connected) {
+      const hasGameId = gameId
+      const isSocketConnected = socket && socket.connected
+
+      if (hasGameId && isSocketConnected) {
         socket.emit('user_disconnect', { gameId })
       }
 

--- a/hooks/use-socket-navigation.ts
+++ b/hooks/use-socket-navigation.ts
@@ -44,18 +44,13 @@ export const useSocketNavigation = (gameId: string | null): UseSocketNavigationR
       return
     }
 
-    if (typeof window !== 'undefined') {
-      window.history.pushState(null, '', window.location.pathname)
-    }
+    window.history.pushState(null, '', window.location.pathname)
 
     const handlePopState = (event: PopStateEvent) => {
       event.preventDefault()
-      if (
-        typeof window !== 'undefined' &&
-        window.confirm('뒤로가기 시, 게임에 다시 입장할 수 없습니다.')
-      ) {
+      if (window.confirm('뒤로가기 시, 게임에 다시 입장할 수 없습니다.')) {
         cleanupAndRedirect()
-      } else if (typeof window !== 'undefined') {
+      } else {
         window.history.pushState(null, '', window.location.pathname)
       }
     }
@@ -73,25 +68,18 @@ export const useSocketNavigation = (gameId: string | null): UseSocketNavigationR
       return ''
     }
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('popstate', handlePopState)
-      window.addEventListener('beforeunload', handleBeforeUnload)
-    }
+    window.addEventListener('popstate', handlePopState)
+    window.addEventListener('beforeunload', handleBeforeUnload)
 
     return () => {
       stopExitTimer()
-
-      if (typeof window !== 'undefined') {
-        window.removeEventListener('popstate', handlePopState)
-        window.removeEventListener('beforeunload', handleBeforeUnload)
-      }
+      window.removeEventListener('popstate', handlePopState)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
     }
-  }, [gameId, socket, cleanupAndRedirect, stopExitTimer])
+  }, [gameId, socket])
 
   useEffect(() => {
-    return () => {
-      stopExitTimer()
-    }
+    return stopExitTimer
   }, [stopExitTimer])
 
   return {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
1. 페이지 이탈 방지 기능 개선 ([#154](https://github.com/your-repo/your-project/issues/154) 해결)
모바일 환경에서 탭을 전환할 때 의도치 않게 게임에서 퇴장 처리되는 문제를 해결하고, 사용자가 페이지를 이탈할 때 명시적인 확인 절차를 거치도록 개선했습니다.
- 모바일 탭 전환: visibilitychange 이벤트를 감지하여, 탭이 비활성화될 때 즉시 퇴장하는 대신 사용자에게 상황을 알리는 모달을 표시하도록 변경했습니다. 이를 통해 사용자는 다시 탭으로 복귀하여 게임을 이어갈 수 있습니다.
- 페이지 이탈 확인: beforeunload 이벤트를 사용하여, 사용자가 브라우저를 닫거나 새로고침 하려고 할 때 "정말 나가시겠습니까?"와 같은 확인창을 띄워 의도하지 않은 이탈을 방지합니다.

2. 소켓 아키텍처 리팩토링
위 기능 개선 과정에서 기존 SocketProvider의 복잡도가 매우 높다는 점(약 800줄)을 발견하여, 코드의 가독성과 유지보수성을 높이기 위한 대규모 리팩토링을 함께 진행했습니다.
- 커스텀 훅 분리: 거대 프로바이더에 있던 로직을 기능 단위(연결, 재연결, 네트워크 상태, 게임 상태 등)로 분리하여 재사용 가능한 커스텀 훅으로 만들었습니다.
- 페이지 단위 적용: 전역으로 관리되던 소켓 로직을 각 페이지의 생명주기에 맞춰 필요한 곳에서만 호출하도록 변경하여, 불필요한 리소스 사용을 줄이고 컴포넌트의 독립성을 강화했습니다.


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

- 페이지 이탈 방지: visibilitychange, beforeunload 이벤트 핸들러 로직 추가 및 개선.
- SocketProvider 리팩토링: 거대 프로바이더를 역할에 따라 여러 개의 커스텀 훅으로 분리.
- 신규 커스텀 훅 추가: useSocketConnection, useSocketReconnection, useNetworkStatus, useTabVisibility, useGameState, useHeartbeat.
- useSocketNavigation 리팩토링: 기존 로직을 새로운 아키텍처에 맞게 개선.
- 적용 방식 변경: 전역 방식에서 페이지 단위로 필요한 훅을 직접 호출하는 방식으로 변경.
- UI 개선: 소켓 연결 오류 및 페이지 이탈 경고를 위한 ErrorModal 연동.

## 📸 스크린샷 (선택 사항)
https://drive.google.com/file/d/1EIeUxggE12ajFABe1SiqZw2R2tCKjqPZ/view?usp=sharing

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

페이지 이탈 방지 워크플로우를 개선하고 소켓 핸들링을 모듈화된 훅으로 리팩토링하며, 네트워크 및 하트비트 상태에 대한 UI 피드백을 강화합니다.

새로운 기능:
- 의도치 않은 게임 종료를 방지하기 위해 모바일 탭 전환 경고 모달 및 브라우저 언로드 확인 기능 추가
- 연결 상태를 주기적으로 확인하고 표시하는 하트비트 메커니즘 구현
- 게임, 사용자 정보, 대기, 결과 페이지 전반에 걸쳐 실시간 네트워크 및 하트비트 지표 표시

개선 사항:
- 모놀리식 SocketProvider를 연결, 재연결, 네트워크 상태, 탭 가시성, 게임 상태를 위한 커스텀 훅으로 분해
- 전역 소켓 로직을 컴포넌트 생명주기에 맞춰 페이지 수준 훅 사용으로 마이그레이션
- 동적 액션 및 카운트다운을 통해 여러 소켓 오류 유형을 지원하도록 ErrorModal 확장

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve page leave prevention workflows and refactor socket handling into modular hooks, while enhancing UI feedback for network and heartbeat status.

New Features:
- Add mobile tab-switch warning modal and browser unload confirmation to prevent unintentional game exits
- Implement heartbeat mechanism to periodically verify and display connection health
- Display real-time network and heartbeat indicators across Game, User Info, Waiting, and Result pages

Enhancements:
- Break down monolithic SocketProvider into custom hooks for connection, reconnection, network status, tab visibility, and game state
- Migrate global socket logic to page-level hook usage aligned with component lifecycles
- Extend ErrorModal to support multiple socket error types with dynamic actions and countdowns

</details>