### PR TITLE
[XX] 브랜치 변경: 배포 환경에서 방 만들기 페이지 이동 안 되는 현상 해결

### DIFF
--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export const POST = async (req: Request) => {
+  const { gameId } = await req.json()
+
+  if (!gameId) {
+    return NextResponse.json({ message: 'gameId is required' }, { status: 400 })
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.set('nyant_session', gameId, {
+    path: '/',
+    maxAge: 60 * 60 * 24,
+    sameSite: 'lax',
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 
 import ChatContainer from '@/components/features/chat/chat-container'
 import FishCoinsAssets from '@/components/features/game/fish-coins-assets'
@@ -44,6 +44,7 @@ const INITIAL_GAME_STATE: GameStateModel = {
 }
 
 const GamePage = () => {
+  const router = useRouter()
   const params = useParams()
   const gameId = params.gameId as string
   const { socket } = useSocket()
@@ -156,6 +157,26 @@ const GamePage = () => {
       setFinalResultState(finalFishPrice)
     }
   }, [serverState, gameResults, finalFishPrice, isResultModalOpen, setFinalResultState])
+
+  useEffect(() => {
+    if (!socket) return
+
+    const handlePlayerInfo = ({ players, playerId: serverPlayerId }) => {
+      const me = players?.find((p) => p.id === serverPlayerId)
+
+      if (!serverPlayerId || !me) {
+        router.replace('/')
+        showToast('잘못된 접근입니다')
+      }
+    }
+
+    socket.on('player_info', handlePlayerInfo)
+    socket.emit('request_player_info', { gameId, playerId })
+
+    return () => {
+      socket.off('player_info', handlePlayerInfo)
+    }
+  }, [socket, gameId, playerId])
 
   const handlePlayerInitialize = ({
     players,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,10 +32,9 @@ const HomePage = () => {
   const handleCreateRoomClick = () => {
     appLogger.log('방 만들기 버튼 클릭됨')
     resetGameState()
-    if (!router) {
-      console.error('Next.js Router is not initialized')
-      return
-    }
+
+    document.cookie = 'nav_pass=1; Path=/; Max-Age=10; SameSite=Lax'
+
     router.push('/setup/select-rounds')
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import Background from '@/components/ui/background'
 import Button from '@/components/ui/button'
 import Input from '@/components/ui/input'
 import { useSocket } from '@/hooks/socket/core/use-socket'
+import { appLogger } from '@/lib/utils/app-logger'
 import { isValidId } from '@/lib/utils/generate-game-id'
 import backgroundDesktopImage from '@/public/images/background-desktop-1.png'
 import backgroundMobileImage from '@/public/images/background-mobile-1.png'
@@ -29,7 +30,12 @@ const HomePage = () => {
   const { setGameId, setIsLeader, resetGameState } = useGameStore()
 
   const handleCreateRoomClick = () => {
+    appLogger.log('방 만들기 버튼 클릭됨')
     resetGameState()
+    if (!router) {
+      console.error('Next.js Router is not initialized')
+      return
+    }
     router.push('/setup/select-rounds')
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ const HomePage = () => {
     appLogger.log('방 만들기 버튼 클릭됨')
     resetGameState()
 
-    document.cookie = 'nav_pass=1; Path=/; Max-Age=10; SameSite=Lax'
+    document.cookie = 'nav_pass=1; Path=/; Max-Age=300; SameSite=Lax'
 
     router.push('/setup/select-rounds')
   }

--- a/app/result/[gameId]/page.tsx
+++ b/app/result/[gameId]/page.tsx
@@ -3,9 +3,8 @@
 import { useEffect, useState } from 'react'
 
 import Image from 'next/image'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 
-import LoadingPage from '@/app/loading'
 import LinkButton from '@/components/ui/link-button'
 import { SITE_URL } from '@/constants/config'
 import { useSocket } from '@/hooks/socket/core/use-socket'
@@ -19,6 +18,7 @@ import { GameResultModel } from '@/types/game'
 const EMPTY_RESULTS: GameResultModel[] = []
 
 const ResultPage = () => {
+  const router = useRouter()
   const params = useParams()
   const gameId = params.gameId as string
 
@@ -43,6 +43,26 @@ const ResultPage = () => {
     const currentPlayer = gameResults.find((result) => result.id === playerId) || null
     setCurrentUser(currentPlayer)
   }, [gameId, gameResults, playerId])
+
+  useEffect(() => {
+    if (!socket) return
+
+    const handlePlayerInfo = ({ players, playerId: serverPlayerId }) => {
+      const me = players?.find((p) => p.id === serverPlayerId)
+
+      if (!serverPlayerId || !me) {
+        router.replace('/')
+        showToast('잘못된 접근입니다')
+      }
+    }
+
+    socket.on('player_info', handlePlayerInfo)
+    socket.emit('request_player_info', { gameId, playerId })
+
+    return () => {
+      socket.off('player_info', handlePlayerInfo)
+    }
+  }, [socket, gameId, playerId])
 
   const handleButtonClick = () => {
     if (!gameResults.length) return

--- a/app/setup/user-info/page.tsx
+++ b/app/setup/user-info/page.tsx
@@ -29,9 +29,21 @@ const UserInfoPage = () => {
   const countInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if (playerId && gameId) {
+    if (!playerId || !gameId) return
+
+    const startSession = async () => {
+      await fetch('/api/session/start', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ gameId }),
+      })
+
       router.push(`/waiting/${gameId}`)
     }
+
+    startSession()
   }, [playerId, gameId, router])
 
   useEffect(() => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,13 +9,18 @@ export const middleware = (request: NextRequest) => {
     return NextResponse.next()
   }
 
-  const referer = request.headers.get('referer')
   const hasSession = request.cookies.has('nyant_session')
+  const hasNavPass = request.cookies.has('nav_pass')
 
-  const isInternalNavigation = referer?.includes(request.nextUrl.hostname)
+  if (hasSession || hasNavPass) {
+    const res = NextResponse.next()
 
-  if (isInternalNavigation || hasSession) {
-    return NextResponse.next()
+    // 일회용 → 즉시 제거
+    if (hasNavPass) {
+      res.cookies.delete('nav_pass')
+    }
+
+    return res
   }
 
   return NextResponse.redirect(new URL('/', request.url))

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ export const middleware = (request: NextRequest) => {
   const referer = request.headers.get('referer')
   const hasSession = request.cookies.has('nyant_session')
 
-  const isInternalNavigation = referer?.includes(request.nextUrl.origin)
+  const isInternalNavigation = referer?.includes(request.nextUrl.hostname)
 
   if (isInternalNavigation || hasSession) {
     return NextResponse.next()

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,27 +5,48 @@ import type { NextRequest } from 'next/server'
 export const middleware = (request: NextRequest) => {
   const { pathname } = request.nextUrl
 
+  // 홈은 항상 허용
   if (pathname === '/') {
     return NextResponse.next()
   }
 
-  const hasSession = request.cookies.has('nyant_session')
   const hasNavPass = request.cookies.has('nav_pass')
+  const sessionGameId = request.cookies.get('nyant_session')?.value
 
-  if (hasSession || hasNavPass) {
-    const res = NextResponse.next()
-
-    // 일회용 → 즉시 제거
-    if (hasNavPass) {
-      res.cookies.delete('nav_pass')
+  /**
+   * setup 단계
+   * - 새로고침 ❌ / 직접 접근 ❌
+   * - nav_pass 필수
+   */
+  if (pathname.startsWith('/setup')) {
+    if (!hasNavPass) {
+      return NextResponse.redirect(new URL('/', request.url))
     }
-
-    return res
+    return NextResponse.next()
   }
 
-  return NextResponse.redirect(new URL('/', request.url))
+  /**
+   * waiting / game / result
+   * - 새로고침 ⭕ / 직접 접근 ❌
+   * - sessionGameId === pathGameId 필수
+   */
+  if (
+    pathname.startsWith('/waiting') ||
+    pathname.startsWith('/game') ||
+    pathname.startsWith('/result')
+  ) {
+    const pathGameId = pathname.split('/')[2]
+
+    if (sessionGameId && sessionGameId === pathGameId) {
+      return NextResponse.next()
+    }
+
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  return NextResponse.next()
 }
 
 export const config = {
-  matcher: ['/waiting/:path*', '/game/:path*', '/result/:path*', '/setup/:path*'],
+  matcher: ['/setup/:path*', '/waiting/:path*', '/game/:path*', '/result/:path*'],
 }

--- a/server/game/handlers.ts
+++ b/server/game/handlers.ts
@@ -188,7 +188,11 @@ export const handleJoinGame = (
       nickname,
       message: `${nickname}님이 입장했습니다.`,
     })
-    socket.emit('join_success', { gameId, playerId })
+    socket.emit('join_success', {
+      gameId,
+      playerId,
+      setSession: true,
+    })
   } catch {
     socket.emit('join_failure', { message: '게임 참가 중 오류가 발생했습니다.' })
   }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
### 작업 내용
- UserInfoPage에서 게임 참여 시 `/api/session/start` 호출로 `nyant_session` 쿠키 생성
- 미들웨어에서 세션이 없는 사용자의 접근 차단 로직 개선
  - 세션 없는 상태에서 `/waiting`, `/game`, `/result` 접근 시 홈으로 리다이렉트
  - setup 단계는 nav_pass 확인 후 접근 허용
- 잘못된 게임 ID 또는 존재하지 않는 방으로 접근 시 홈으로 돌아가도록 처리

### 해결한 문제
- 세션 쿠키가 없거나 유효하지 않은 상태에서 임의 URL 접근 시 홈으로 돌아가는 문제 해결
- 정보 입력 후 게임 참여 시 클라이언트가 홈으로 리다이렉트되는 문제 수정
- 미등록 방이나 잘못된 게임 ID 접근 시 불필요한 방이 생성되는 현상 방지

### 참고
- `/api/session/start`는 App Router 기반으로 구현
- `nyant_session` 쿠키는 1일 동안 유효하며 SameSite=Lax 설정
- 미들웨어 로그 `[MW]`로 접근 상태 확인 가능

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Summary by Sourcery

라우팅 동작과 요청 미들웨어 조건을 조정하여, 프로덕션 환경에서 방 생성 내비게이션이 안정적으로 작동하도록 합니다.

버그 수정:
- 초기화되지 않은 Next.js 라우터로 인해 방 생성 플로우로 이동할 때 발생하는 실패를 방지하기 위해 가드를 추가했습니다.
- 전체 오리진 대신 요청 호스트 이름과 `Referer` 헤더를 비교하도록 변경하여, 세션 미들웨어가 내부 내비게이션을 올바르게 감지하도록 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure room creation navigation works reliably in production by adjusting routing behavior and request middleware conditions.

Bug Fixes:
- Prevent failures when navigating to the room creation flow by guarding against an uninitialized Next.js router.
- Fix session middleware detection of internal navigation by comparing the Referer header against the request hostname instead of the full origin.

</details>